### PR TITLE
Allow arbitrary expressions in attribute_path.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,3 +10,4 @@
 #     Name <email address>
 
 Mathieu Boespflug <m@tweag.io>
+Mateusz Kowalczyk <mateusz.kowalczyk@tweag.io>

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,3 +10,22 @@ nixpkgs_git_repository(
 )
 
 nixpkgs_package(name = "hello", repository = "@nixpkgs")
+
+nixpkgs_package(
+  name = "expr-test",
+  expression = "let pkgs = import <nixpkgs> {}; in pkgs.hello",
+  repository = "@nixpkgs"
+)
+
+nixpkgs_package(
+  name = "attribute-test",
+  attribute = "hello",
+  repository = "@nixpkgs"
+)
+
+nixpkgs_package(
+  name = "expr-attribute-test",
+  expression = "import <nixpkgs> {}",
+  attribute = "hello",
+  repository = "@nixpkgs",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,13 +19,13 @@ nixpkgs_package(
 
 nixpkgs_package(
   name = "attribute-test",
-  attribute = "hello",
+  attribute_path = "hello",
   repository = "@nixpkgs"
 )
 
 nixpkgs_package(
   name = "expr-attribute-test",
   expression = "import <nixpkgs> {}",
-  attribute = "hello",
+  attribute_path = "hello",
   repository = "@nixpkgs",
 )

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -20,13 +20,13 @@ def _mk_build_expression(ctx):
   """
   # If user specified expression only, use expression only: they may
   # be picking their attributes in the expression itself already.
-  if ctx.attr.expression and not ctx.attr.attribute:
+  if ctx.attr.expression and not ctx.attr.attribute_path:
     return ["-E", ctx.attr.expression]
   # In all other cases we can craft a correct query by using user's
   # input with some defaults.
   else:
     return ["-E", ctx.attr.expression or "import <nixpkgs> {}",
-            "-A", ctx.attr.attribute or ctx.attr.name]
+            "-A", ctx.attr.attribute_path or ctx.attr.name]
 
 def _nixpkgs_package_impl(ctx):
   if ctx.attr.build_file and ctx.attr.build_file_content:
@@ -64,7 +64,7 @@ def _nixpkgs_package_impl(ctx):
 nixpkgs_package = repository_rule(
   implementation = _nixpkgs_package_impl,
   attrs = {
-    "attribute": attr.string(
+    "attribute_path": attr.string(
       doc="Nix attribute to build. Exclusive to expression."
     ),
     "expression": attr.string(

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,9 +1,14 @@
 package(default_testonly = 1)
 
-sh_test(
-  name = "run-hello",
+[sh_test(
+  name= "run-{0}".format(test),
   srcs = ["test_bin.sh"],
-  args = ["$(location @hello//:bin)"],
-  data = ["@hello//:bin"],
+  args=["$(location @{0}//:bin)".format(test)],
+  data = ["@{0}//:bin".format(test)],
   timeout = "short",
-)
+) for test in [
+    "hello",
+    "expr-test",
+    "attribute-test",
+    "expr-attribute-test",
+]]


### PR DESCRIPTION
This allows more advanced attributes to be used. Motivating use-case
is ghcWithPackages.