### PR TITLE
Find _all_ shared object files in a lib filegroup.

### DIFF
--- a/nixpkgs/BUILD.pkg
+++ b/nixpkgs/BUILD.pkg
@@ -7,5 +7,5 @@ filegroup(
 
 filegroup(
   name = "lib",
-  srcs = glob(["nix/lib/*.so"]),
+  srcs = glob(["nix/lib/**/*.so"]),
 )


### PR DESCRIPTION
This allows us to use libs that aren't living directly in the top
level lib output. An example is libjvm.so in openjdk package.

Do we want to have some kind of test for this?