### PR TITLE
Use ctx.which to find nix-build

### DIFF
--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -55,7 +55,11 @@ def _nixpkgs_package_impl(ctx):
   if ctx.attr.path:
     path = ["-I", "nixpkgs={0}".format(ctx.attr.path)]
 
-  nix_build = ["nix-build"] + path + ["--no-out-link"] + expr_args
+  nix_build_path = ctx.which("nix-build")
+  if nix_build_path == None:
+    fail("Could not find nix-build on the path. Please install it. See: https://nixos.org/nix/")
+
+  nix_build = [nix_build_path] + path + ["--no-out-link"] + expr_args
 
   res = ctx.execute(nix_build, quiet = False)
   if res.return_code == 0:


### PR DESCRIPTION
the current rules assume `nix-build` just works. If it doesn't you get a cryptic message.

I added a call to which. If that fails we print that nix-build was not found. If it is found, we use that path in our call.

I verified that I saw the error message on my machine without nix installed, then installed nix and verified I can then run the tests.

The `which` path was needed for me to be able to run on OSX.