### PR TITLE
Allow repository rule to check for sha

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository", "
 nixpkgs_git_repository(
     name = "nixpkgs",
     revision = "17.09", # Any tag or commit hash
+    sha256 = "" # optional sha to verify package integrity!
 )
 
 nixpkgs_package(
@@ -44,7 +45,7 @@ nixpkgs_package(
 Name a specific revision of Nixpkgs on GitHub or a local checkout.
 
 ```bzl
-nixpkgs_git_repository(name, revision)
+nixpkgs_git_repository(name, revision, sha256)
 ```
 
 <table class="table table-condensed table-bordered table-params">
@@ -71,6 +72,13 @@ nixpkgs_git_repository(name, revision)
         <p><code>String; optional</code></p>
         <p>Git commit hash or tag identifying the version of Nixpkgs
            to use.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>sha256</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>The SHA256 used to verify the integrity of the repository</p>
       </td>
     </tr>
   </tbody>

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,6 +7,7 @@ load("//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository", "nixpkgs_package")
 nixpkgs_git_repository(
   name = "nixpkgs",
   revision = "17.09",
+  sha256 = "405f1d6ba523630c83fbabef93f0da11ea388510a576adf2ded26a744fbf793e",
 )
 
 nixpkgs_package(name = "hello", repository = "@nixpkgs")

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -7,12 +7,16 @@ def _nixpkgs_git_repository_impl(ctx):
   ctx.download_and_extract(
     url = "https://github.com/NixOS/nixpkgs/archive/%s.tar.gz" % ctx.attr.revision,
     stripPrefix = "nixpkgs-" + ctx.attr.revision,
+    sha256 = ctx.attr.sha256,
   )
 
 nixpkgs_git_repository = repository_rule(
   implementation = _nixpkgs_git_repository_impl,
   attrs = {
     "revision": attr.string(),
+    "sha256": attr.string(
+      default = "",
+      ),
   },
   local = False,
 )


### PR DESCRIPTION
Hello! And thanks a lot for putting these together :)

It felt a bit unidiomatic bazel usage to see that suggested sha every time I did a build because the rule didn't pass a sha along to `download_and_extract`, so I figured I would contribute the fix.

Easy peasy, now the contents of the repo are verified too! 🎉 