### PR TITLE
Recursively search headers in default BUILD file

### DIFF
--- a/nixpkgs/BUILD.pkg
+++ b/nixpkgs/BUILD.pkg
@@ -12,5 +12,5 @@ filegroup(
 
 filegroup(
   name = "include",
-  srcs = glob(["include/*.h"]),
+  srcs = glob(["include/**/*.h"]),
 )


### PR DESCRIPTION
Allows e.g. getting headers from `${openssl.dev}/include/openssl/`