### PR TITLE
Force explicit nixpkgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Changed
+
+* `nixpkgs_packages` does not accept implicit `<nixpkgs>` version. See
+   [#25](https://github.com/tweag/rules_nixpkgs/pull/25).
+
 ## [0.2.3] - 2018-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -103,9 +103,8 @@ nixpkgs_package(
 )
 ```
 
-If neither `repository` or `path` are specified, `<nixpkgs>` is
-assumed. Specifying one of `repository` or `path` is strongly
-recommended. The two are mutually exclusive.
+If neither `repository` or `path` are specified, you must provide a
+nixpkgs clone in `nix_file` or `nix_file_content`.
 
 <table class="table table-condensed table-bordered table-params">
   <colgroup>


### PR DESCRIPTION
This closes #24 by forcing an explicit `nixpkgs` clone.

- If the user provides no `nix_file`, and no `path` or `repository`, it fails with a bazel error
- If the user provides a `nix_file`, there is no solution to detect if the file is indeed using a pinned nixpkgs clone. We just override `NIX_PATH` to an invalid path and hop for the best

I'm not happy with the way I'm abusing `NIX_PATH` to write an error message. Any better idea?