### PR TITLE
Allow passing several labels to `nixpkgs_package`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,8 @@ jobs:
       - run:
           name: System dependencies
           command: |
-            export NIX_PATH=nixpkgs=$PWD/nix/default.nix
             apk update --no-progress && apk --no-progress add bash ca-certificates
-            nix-env -iA nixpkgs.bazel nixpkgs.gcc
       - run:
           name: Run tests
-          command: bazel test //...
+          command: |
+            nix-shell --pure --run 'bazel test //...'

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ nixpkgs_git_repository(
 
 nixpkgs_package(
     name = "hello",
-    repository = "@nixpkgs"
+    repositories = { "@nixpkgs": "nixpkgs" }
 )
 ```
 
@@ -160,8 +160,15 @@ nixpkgs clone in `nix_file` or `nix_file_content`.
       <td><code>repository</code></td>
       <td>
         <p><code>Label; optional</code></p>
-        <p>A Nixpkgs repository label. Specify one of `path` or
-		   `repository`.</p>
+        <p>Deprecated, use `repositories` instead.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>repositorie</code></td>
+      <td>
+        <p><code>Label-keyed String dict; optional</code></p>
+        <p>A dictionary mapping repositoriy labels to `NIX_PATH` entries.
+        Specify one of `path` or `repositories`.</p>
       </td>
     </tr>
     <tr>
@@ -170,7 +177,7 @@ nixpkgs clone in `nix_file` or `nix_file_content`.
         <p><code>String; optional</code></p>
         <p>The path to the directory containing Nixpkgs, as
            interpreted by `nix-build`. Specify one of `path` or
-		   `repository`.</p>
+		   `repositories`.</p>
       </td>
     </tr>
     <tr>

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,37 +4,37 @@ load("//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository", "nixpkgs_package")
 
 # For tests
 
-nixpkgs_package(name = "hello", repositories = { "//:nix/default.nix": "nixpkgs" })
+nixpkgs_package(name = "hello", repositories = { "nixpkgs": "//:nix/default.nix" })
 
 nixpkgs_package(
   name = "expr-test",
   nix_file_content = "let pkgs = import <nixpkgs> {}; in pkgs.hello",
-  repositories = { "//:nix/default.nix": "nixpkgs" }
+  repositories = { "nixpkgs": "//:nix/default.nix" }
 )
 
 nixpkgs_package(
   name = "attribute-test",
   attribute_path = "hello",
-  repositories = { "//:nix/default.nix": "nixpkgs" }
+  repositories = { "nixpkgs": "//:nix/default.nix" }
 )
 
 nixpkgs_package(
   name = "expr-attribute-test",
   nix_file_content = "import <nixpkgs> {}",
   attribute_path = "hello",
-  repositories = { "//:nix/default.nix": "nixpkgs" },
+  repositories = { "nixpkgs": "//:nix/default.nix" },
 )
 
 nixpkgs_package(
   name = "nix-file-test",
   nix_file = "//tests:nixpkgs.nix",
   attribute_path = "hello",
-  repositories = { "//:nix/default.nix": "nixpkgs" },
+  repositories = { "nixpkgs": "//:nix/default.nix" },
 )
 
 nixpkgs_package(
   name = "nix-file-deps-test",
   nix_file = "//tests:hello.nix",
   nix_file_deps = ["//tests:pkgname.nix"],
-  repositories = { "//:nix/default.nix": "nixpkgs" },
+  repositories = { "nixpkgs": "//:nix/default.nix" },
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,44 +4,37 @@ load("//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository", "nixpkgs_package")
 
 # For tests
 
-nixpkgs_git_repository(
-  name = "nixpkgs",
-  revision = "17.09",
-  sha256 = "405f1d6ba523630c83fbabef93f0da11ea388510a576adf2ded26a744fbf793e",
-)
-
-nixpkgs_package(name = "hello", repository = "//:nix/default.nix")
+nixpkgs_package(name = "hello", repositories = { "//:nix/default.nix": "nixpkgs" })
 
 nixpkgs_package(
   name = "expr-test",
   nix_file_content = "let pkgs = import <nixpkgs> {}; in pkgs.hello",
-  repository = "//:nix/default.nix"
+  repositories = { "//:nix/default.nix": "nixpkgs" }
 )
 
 nixpkgs_package(
   name = "attribute-test",
   attribute_path = "hello",
-  repository = "//:nix/default.nix"
+  repositories = { "//:nix/default.nix": "nixpkgs" }
 )
 
 nixpkgs_package(
   name = "expr-attribute-test",
   nix_file_content = "import <nixpkgs> {}",
   attribute_path = "hello",
-  repository = "//:nix/default.nix",
+  repositories = { "//:nix/default.nix": "nixpkgs" },
 )
 
 nixpkgs_package(
   name = "nix-file-test",
   nix_file = "//tests:nixpkgs.nix",
   attribute_path = "hello",
-  repository = "//:nix/default.nix",
+  repositories = { "//:nix/default.nix": "nixpkgs" },
 )
 
 nixpkgs_package(
   name = "nix-file-deps-test",
   nix_file = "//tests:hello.nix",
   nix_file_deps = ["//tests:pkgname.nix"],
-  repository = "//:nix/default.nix",
+  repositories = { "//:nix/default.nix": "nixpkgs" },
 )
-

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -116,7 +116,7 @@ def _nixpkgs_package_impl(ctx):
   _symlink_children(output_path, ctx)
 
 
-nixpkgs_package = repository_rule(
+_nixpkgs_package = repository_rule(
   implementation = _nixpkgs_package_impl,
   attrs = {
     "attribute_path": attr.string(),
@@ -131,6 +131,19 @@ nixpkgs_package = repository_rule(
   },
   local = True,
 )
+
+def nixpkgs_package(repositories, *args, **kwargs):
+    # Because of https://github.com/bazelbuild/bazel/issues/5356 we can't
+    # directly pass a dict from strings to labels to the rule (which we'd like
+    # for the `repositories` arguments), but we can pass a dict from labels to
+    # strings. So we swap the keys and the values (assuming they all are
+    # distinct).
+    inversed_repositories = { value: key for (key, value) in repositories.items() }
+    _nixpkgs_package(
+        repositories = inversed_repositories,
+        *args,
+        **kwargs
+    )
 
 def _symlink_children(target_dir, rep_ctx):
   """Create a symlink to all children of `target_dir` in the current

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import ./nix/default.nix {} }:
+
+with pkgs;
+
+mkShell {
+  buildInputs = [
+    bazel
+    gcc
+    nix
+  ];
+}


### PR DESCRIPTION
Deprecates the `repository` attribute in favor of the more general
`repositories` which expects a dict of the form

```python
{
  "@some_label": "some_name",
  "@some_other_label": "some_other_name",
}
```

and generating the `NIX_PATH`
`some_name=path(@some_label):some_other_name=path(@some_other_label)`

-----------

I also have a couple of questions regarding this:

- I would prefer having the dict be `{ "name": "@label"}` instead of `{ "@labelb: "name"}`, but the docs at https://docs.bazel.build/versions/master/skylark/lib/attr.html only mentions `label_keyed_string_dict` and not something like `string_keyed_label_dict`. Does anyone knows whether there is a way to build custom types for attrs?
- I have manually updated the documentation in the `README`. Is it the right way to do so or is it generated in some way?