### PR TITLE
circle-ci: print error logs for failing tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,4 +14,4 @@ jobs:
       - run:
           name: Run tests
           command: |
-            nix-shell --pure --run 'bazel test //...'
+            nix-shell --pure --run 'bazel test --test_output errors //...'


### PR DESCRIPTION
This is necessary for #35 to print test failure logs.