### PR TITLE
Fix repositories argument being required (bump 0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.3.1] - 2018-10-24
+
+### Fixed
+
+* `repositories` is no longer a required argument to `nixpkgs_package`.
+
 ## [0.3] - 2018-10-23
 
 ### Added

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,8 @@ nixpkgs_package(
 
 nixpkgs_package(
   name = "hello",
-  repositories = { "nixpkgs": "//:nixpkgs.nix" }
+  # deliberately not repositories, to test whether repository still works
+  repository = "//:nixpkgs.nix"
 )
 
 nixpkgs_package(

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -124,18 +124,22 @@ _nixpkgs_package = repository_rule(
   local = True,
 )
 
-def nixpkgs_package(repositories, *args, **kwargs):
-    # Because of https://github.com/bazelbuild/bazel/issues/5356 we can't
-    # directly pass a dict from strings to labels to the rule (which we'd like
-    # for the `repositories` arguments), but we can pass a dict from labels to
-    # strings. So we swap the keys and the values (assuming they all are
-    # distinct).
-    inversed_repositories = { value: key for (key, value) in repositories.items() }
+def nixpkgs_package(*args, **kwargs):
+  # Because of https://github.com/bazelbuild/bazel/issues/5356 we can't
+  # directly pass a dict from strings to labels to the rule (which we'd like
+  # for the `repositories` arguments), but we can pass a dict from labels to
+  # strings. So we swap the keys and the values (assuming they all are
+  # distinct).
+  if "repositories" in kwargs:
+    inversed_repositories = { value: key for (key, value) in kwargs["repositories"].items() }
+    kwargs.pop("repositories")
     _nixpkgs_package(
-        repositories = inversed_repositories,
-        *args,
-        **kwargs
+      repositories = inversed_repositories,
+      *args,
+      **kwargs
     )
+  else:
+    _nixpkgs_package(*args, **kwargs)
 
 def _symlink_children(target_dir, rep_ctx):
   """Create a symlink to all children of `target_dir` in the current


### PR DESCRIPTION
This was a regression in 0.3. The idea was that we could be backwards
compatible with (the deprecated) `repository` field, so `repositories`
has to be optional.