### PR TITLE
Restore short repository labels

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,7 +18,7 @@ nixpkgs_git_repository(
 
 nixpkgs_package(
     name = "nixpkgs-git-repository-test",
-    repositories = { "nixpkgs": "@remote_nixpkgs//:default.nix" },
+    repositories = { "nixpkgs": "@remote_nixpkgs" },
     attribute_path = "hello",
 )
 
@@ -80,4 +80,4 @@ filegroup(
 """,
 )
 
-nixpkgs_cc_configure(repository = "@remote_nixpkgs//:default.nix")
+nixpkgs_cc_configure(repository = "@remote_nixpkgs")

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -4,8 +4,9 @@ load("@bazel_tools//tools/cpp:cc_configure.bzl", "cc_autoconf_impl")
 
 def _nixpkgs_git_repository_impl(repository_ctx):
   repository_ctx.file('BUILD')
-  # XXX Hack because repository_ctx.path below bails out if resolved path not a regular file.
-  repository_ctx.file(repository_ctx.name)
+  # Make "@nixpkgs" (syntactic sugar for "@nixpkgs//:nixpkgs") a valid
+  # label for default.nix.
+  repository_ctx.symlink("default.nix", repository_ctx.name)
   repository_ctx.download_and_extract(
     url = "%s/archive/%s.tar.gz" % (repository_ctx.attr.remote, repository_ctx.attr.revision),
     stripPrefix = "nixpkgs-" + repository_ctx.attr.revision,


### PR DESCRIPTION
Before #29, we'd write

```python
nixpkgs_package(name = "hello", repository = "@nixpkgs")
```

and this would just work. Now we write

```python
nixpkgs_package(name = "hello", repositories = { "nixpkgs": "@nixpkgs//:default.nix" })
```

which is quite a bit more verbose. With this fix, writing the
repository label as `"@nixpkgs"` works again.

Fixes #41.