### PR TITLE
Implement nixpkgs_local_repository()

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,58 @@ nixpkgs_git_repository(name, revision, sha256)
   </tbody>
 </table>
 
+### nixpkgs_local_repository
+
+Create an external repository representing the content of Nixpkgs,
+based on a Nix expression stored locally or provided inline. One of
+`nix_file` or `nix_file_content` must be provided.
+
+```bzl
+nixpkgs_local_repository(name, nix_file, nix_file_deps, nix_file_content)
+```
+
+<table class="table table-condensed table-bordered table-params">
+  <colgroup>
+    <col class="col-param" />
+    <col class="param-description" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th colspan="2">Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>name</code></td>
+      <td>
+        <p><code>Name; required</code></p>
+        <p>A unique name for this repository.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>nix_file</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>A file containing an expression for a Nix derivation.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>nix_file_deps</code></td>
+      <td>
+        <p><code>List of labels; optional</code></p>
+        <p>Dependencies of `nix_file` if any.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>nix_file_content</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>An expression for a Nix derivation.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ### nixpkgs_package
 
 Make the content of a Nixpkgs package available in the Bazel workspace.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,6 +4,7 @@ load(
     "//nixpkgs:nixpkgs.bzl",
     "nixpkgs_cc_configure",
     "nixpkgs_git_repository",
+    "nixpkgs_local_repository",
     "nixpkgs_package"
 )
 
@@ -16,6 +17,11 @@ nixpkgs_git_repository(
   sha256 = "6451af4083485e13daa427f745cbf859bc23cb8b70454c017887c006a13bd65e",
 )
 
+nixpkgs_local_repository(
+  name = "nixpkgs",
+  nix_file = "//:nixpkgs.nix",
+)
+
 nixpkgs_package(
     name = "nixpkgs-git-repository-test",
     repositories = { "nixpkgs": "@remote_nixpkgs" },
@@ -24,53 +30,54 @@ nixpkgs_package(
 
 nixpkgs_package(
   name = "hello",
-  # deliberately not repositories, to test whether repository still works
-  repository = "//:nixpkgs.nix"
+  # Deliberately not repository, to test whether repositories works.
+  repositories = { "nixpkgs": "@nixpkgs" }
 )
 
 nixpkgs_package(
   name = "expr-test",
   nix_file_content = "let pkgs = import <nixpkgs> {}; in pkgs.hello",
+  # Deliberately not @nixpkgs, to test whether explict file works.
   repositories = { "nixpkgs": "//:nixpkgs.nix" }
 )
 
 nixpkgs_package(
   name = "attribute-test",
   attribute_path = "hello",
-  repositories = { "nixpkgs": "//:nixpkgs.nix" }
+  repository = "@nixpkgs"
 )
 
 nixpkgs_package(
   name = "expr-attribute-test",
   nix_file_content = "import <nixpkgs> {}",
   attribute_path = "hello",
-  repositories = { "nixpkgs": "//:nixpkgs.nix" },
+  repository = "@nixpkgs",
 )
 
 nixpkgs_package(
   name = "nix-file-test",
   nix_file = "//tests:nixpkgs.nix",
   attribute_path = "hello",
-  repositories = { "nixpkgs": "//:nixpkgs.nix" },
+  repository = "@nixpkgs",
 )
 
 nixpkgs_package(
   name = "nix-file-deps-test",
   nix_file = "//tests:hello.nix",
   nix_file_deps = ["//tests:pkgname.nix"],
-  repositories = { "nixpkgs": "//:nixpkgs.nix" },
+  repository = "@nixpkgs",
 )
 
 nixpkgs_package(
   name = "output-filegroup-test",
   nix_file = "//tests:output.nix",
-  repositories = { "nixpkgs": "//:nixpkgs.nix" },
+  repository = "@nixpkgs",
 )
 
 nixpkgs_package(
   name = "output-filegroup-manual-test",
   nix_file = "//tests:output.nix",
-  repositories = { "nixpkgs": "//:nixpkgs.nix" },
+  repository = "@nixpkgs",
   build_file_content = """
 package(default_visibility = [ "//visibility:public" ])
 filegroup(


### PR DESCRIPTION
This rule does not add any new expressive power, because we can
already provide a Nix expression in a local file directly using the
`repository` or `repositories` attributes. The arguments for adding it
are:

* consistency. Where there is a native `local_repository` and
  `git_repository`, there are now rules_nixpkgs equivalents of both.
* Abstraction. When the Nixpkgs we want to use is pulled directly from
  Git, we don't have much of a choice but to declare a new external
  repository for it in Bazel. We can the refer to this repository
  simply as `@nixpkgs` in all `nixpkgs_package` declarations. It's
  better if whether the repository comes from Git or is local becomes
  an irrelevant concern at call sites, i.e. that it is abstracted
  away.