### PR TITLE
Exposed nixpkgs_cc_autoconf & nixpkgs_cc_autoconf_impl

### DIFF
--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -182,7 +182,7 @@ def nixpkgs_package(*args, **kwargs):
     else:
         _nixpkgs_package(*args, **kwargs)
 
-def _nixpkgs_cc_autoconf_impl(repository_ctx):
+def nixpkgs_cc_autoconf_impl(repository_ctx):
     # Calling repository_ctx.path() on anything but a regular file
     # fails. So the roundabout way to do the same thing is to find
     # a regular file we know is in the workspace (i.e. the WORKSPACE
@@ -206,8 +206,8 @@ def _nixpkgs_cc_autoconf_impl(repository_ctx):
     }
     cc_autoconf_impl(repository_ctx, overriden_tools = overriden_tools)
 
-_nixpkgs_cc_autoconf = repository_rule(
-    implementation = _nixpkgs_cc_autoconf_impl,
+nixpkgs_cc_autoconf = repository_rule(
+    implementation = nixpkgs_cc_autoconf_impl,
 )
 
 def nixpkgs_cc_configure(
@@ -242,7 +242,7 @@ def nixpkgs_cc_configure(
 
     # Following lines should match
     # https://github.com/bazelbuild/bazel/blob/master/tools/cpp/cc_configure.bzl#L93.
-    _nixpkgs_cc_autoconf(name = "local_config_cc")
+    nixpkgs_cc_autoconf(name = "local_config_cc")
     native.bind(name = "cc_toolchain", actual = "@local_config_cc//:toolchain")
     native.register_toolchains("@local_config_cc//:all")
 


### PR DESCRIPTION
This allows conditional run of `nixpkgs_cc_autoconf` from within another / custom rule, for example to incl. it only on non-windows hosts:

```
def _optional_nix_cc_configure_rule_impl(repository_ctx):
    cpu_value = get_cpu_value(repository_ctx)

    if cpu_value != "x64_windows":
        cc_autoconf_impl(repository_ctx)
    else:
        nixpkgs_cc_autoconf_impl(repository_ctx)
```

and is in line with `cc_autoconf` and `cc_autoconf_impl`:
https://github.com/bazelbuild/bazel/blob/master/tools/cpp/cc_configure.bzl#L25
https://github.com/bazelbuild/bazel/blob/master/tools/cpp/cc_configure.bzl#L58