### PR TITLE
Capture `.dylib` in `lib` filegroup

### DIFF
--- a/nixpkgs/BUILD.pkg
+++ b/nixpkgs/BUILD.pkg
@@ -7,7 +7,7 @@ filegroup(
 
 filegroup(
     name = "lib",
-    srcs = glob(["lib/**/*.so*", "lib/**/*.a"]),
+    srcs = glob(["lib/**/*.so*", "lib/**/*.dylib", "lib/**/*.a"]),
 )
 
 filegroup(


### PR DESCRIPTION
So that the `lib` `filegroup` also works on MacOS.