### PR TITLE
Allow nixpkgs_package rules to not fail on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+### Added
+- `nixpkgs_package` now has a new optional argument `fail_not_supported`
+  allowing the rule to _not_ fail on Windows (when set to `False`)
+
 ## [0.5.1] - 2018-12-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Make the content of a Nixpkgs package available in the Bazel workspace.
 nixpkgs_package(
     name, attribute_path, nix_file, nix_file_deps, nix_file_content,
     repository, repositories, build_file, build_file_content,
+    fail_not_supported,
 )
 ```
 
@@ -274,6 +275,18 @@ filegroup(
         <p><code>String; optional</code></p>
         <p>Like <code>build_file</code>, but a string of the contents
           instead of a file name.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>fail_not_supported</code></td>
+      <td>
+        <p><code>Boolean; optional; default = True</code></p>
+        <p>
+            If set to <code>True</code> (default) this rule will fail on
+            platforms which do not support Nix (e.g. Windows). If set to
+            <code>False</code> calling this rule will succeed but no output
+            will be generated.
+        </p>
       </td>
     </tr>
   </tbody>

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -174,7 +174,7 @@ _nixpkgs_package = repository_rule(
         "build_file_content": attr.string(),
         "nixopts": attr.string_list(),
         "fail_not_supported": attr.bool(default = True, doc = """
-            If set to True (default) this rule will failed on platforms which do not support Nix (e.g. Windows). If set to False calling this rule will succeed but no output will be generated.
+            If set to True (default) this rule will fail on platforms which do not support Nix (e.g. Windows). If set to False calling this rule will succeed but no output will be generated.
                                         """),
     },
 )


### PR DESCRIPTION
This adds a flag `fail_not_supported` to `nixpkgs_package()` that specifies whether or not the rule should fail on unsupported platforms. If set to <code>True</code> (default) this rule will fail on platforms which do not support Nix (e.g. Windows). If set to <code>False</code> calling this rule will succeed but no output will be generated.

This flag is needed because `nixpkgs_package()` is a `WORKSPACE` rule, and `WORKSPACE`s cannot have conditional execution based on the platform.

See also: https://github.com/tweag/rules_haskell/issues/570 https://github.com/tweag/rules_haskell/issues/559