### PR TITLE
Exposing nixopts in nixpkgs_cc_configure.

### DIFF
--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -255,7 +255,8 @@ def nixpkgs_cc_configure(
         repositories = {},
         nix_file = None,
         nix_file_deps = None,
-        nix_file_content = None):
+        nix_file_content = None,
+        nixopts = []):
     """Use a CC toolchain from Nixpkgs. No-op if not on Linux or Darwin.
 
     By default, Bazel auto-configures a CC toolchain from commands (e.g.
@@ -278,6 +279,7 @@ def nixpkgs_cc_configure(
         nix_file_deps = nix_file_deps,
         nix_file_content = nix_file_content,
         build_file_content = """exports_files(glob(["bin/*"]))""",
+        nixopts = nixopts,
     )
 
     # Following lines should match


### PR DESCRIPTION
Dependency of https://github.com/tweag/rules_haskell/pull/574

In order to build `rules_haskell` in a docker environment with nix >= 2.2, we need to disable the nix-sandbox when calling `nixpkgs_cc_configure`. 

We need an access to the nix options used by the internal `nixpkgs_package` call.

See https://github.com/tweag/rules_haskell/issues/591 for more information about the incentives.
