### PR TITLE
Testing nix-build using reposity_ctx.which()

### DIFF
--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -57,7 +57,7 @@ nixpkgs_local_repository = repository_rule(
 )
 
 def _is_supported_platform(repository_ctx):
-    return repository_ctx.execute(["nix-build","--version"]).return_code == 0
+    return repository_ctx.which("nix-build") != None
 
 def _nixpkgs_package_impl(repository_ctx):
     repository = repository_ctx.attr.repository


### PR DESCRIPTION
Using the `type -p` bash builtin instead of `nix-build --version` to
test whether nix-build is in `$PATH`. This results in a ~x4 speedup
while still compatible with windows, darwin and linux.