### PR TITLE
Replace readlink by builtin realpath

### DIFF
--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -200,9 +200,7 @@ def nixpkgs_package(*args, **kwargs):
         _nixpkgs_package(*args, **kwargs)
 
 def _readlink(repository_ctx, path):
-    return _execute_or_fail(
-        repository_ctx, ["readlink", path],
-    ).stdout.rstrip()
+    return repository_ctx.path(path).realpath
 
 def nixpkgs_cc_autoconf_impl(repository_ctx):
     cpu_value = get_cpu_value(repository_ctx)


### PR DESCRIPTION
readlink is not available or behaves differently on MacOS, so that `_readlink` fails on MacOS.

This change instead uses the `realpath` attribute on `path` objects, which also resolves all symlinks.