### PR TITLE
Nix command should be quiet

### DIFF
--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -152,7 +152,6 @@ def _nixpkgs_package_impl(repository_ctx):
             failure_message = "Cannot build Nix attribute '{}'.".format(
                 repository_ctx.attr.attribute_path,
             ),
-            quiet = False,
             timeout = timeout,
             environment = dict(NIX_PATH = nix_path),
         )


### PR DESCRIPTION
Bazel policy states that successful command should not provide any
output.

The `quiet` setting was set to `False` initially to see progress of nix
command. Newest bazel version includes a progress indicator for
external repositories.