### PR TITLE
Disable implicit nixpkgs config file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,7 +36,7 @@ nixpkgs_package(
 
 nixpkgs_package(
     name = "expr-test",
-    nix_file_content = "let pkgs = import <nixpkgs> {}; in pkgs.hello",
+    nix_file_content = "let pkgs = import <nixpkgs> { config = {}; }; in pkgs.hello",
     # Deliberately not @nixpkgs, to test whether explict file works.
     repositories = {"nixpkgs": "//:nixpkgs.nix"},
 )
@@ -50,7 +50,7 @@ nixpkgs_package(
 nixpkgs_package(
     name = "expr-attribute-test",
     attribute_path = "hello",
-    nix_file_content = "import <nixpkgs> {}",
+    nix_file_content = "import <nixpkgs> { config = {}; }",
     repository = "@nixpkgs",
 )
 
@@ -77,7 +77,7 @@ nixpkgs_package(
 nixpkgs_package(
     name = "extra-args-test",
     nix_file_content = """
-{ packagePath }: (import <nixpkgs> {}).${packagePath}
+{ packagePath }: (import <nixpkgs> { config = {}; }).${packagePath}
     """,
     repository = "@nixpkgs",
     nixopts = ["--argstr", "packagePath", "hello"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,7 +36,7 @@ nixpkgs_package(
 
 nixpkgs_package(
     name = "expr-test",
-    nix_file_content = "let pkgs = import <nixpkgs> { config = {}; }; in pkgs.hello",
+    nix_file_content = "let pkgs = import <nixpkgs> { config = {}; overlays = []; }; in pkgs.hello",
     # Deliberately not @nixpkgs, to test whether explict file works.
     repositories = {"nixpkgs": "//:nixpkgs.nix"},
 )
@@ -50,7 +50,7 @@ nixpkgs_package(
 nixpkgs_package(
     name = "expr-attribute-test",
     attribute_path = "hello",
-    nix_file_content = "import <nixpkgs> { config = {}; }",
+    nix_file_content = "import <nixpkgs> { config = {}; overlays = []; }",
     repository = "@nixpkgs",
 )
 
@@ -77,7 +77,7 @@ nixpkgs_package(
 nixpkgs_package(
     name = "extra-args-test",
     nix_file_content = """
-{ packagePath }: (import <nixpkgs> { config = {}; }).${packagePath}
+{ packagePath }: (import <nixpkgs> { config = {}; overlays = []; }).${packagePath}
     """,
     repository = "@nixpkgs",
     nixopts = ["--argstr", "packagePath", "hello"],

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -97,7 +97,7 @@ def _nixpkgs_package_impl(repository_ctx):
     elif not repositories:
         fail(strFailureImplicitNixpkgs)
     else:
-        expr_args = ["-E", "import <nixpkgs> { config = {}; }"]
+        expr_args = ["-E", "import <nixpkgs> { config = {}; overlays = []; }"]
 
     _symlink_nix_file_deps(repository_ctx, repository_ctx.attr.nix_file_deps)
 
@@ -239,9 +239,9 @@ nix_file_deps = [
     "{deps_listing}",
 ]
 
-Note: if it points to the nixpkgs global configuration file, such as ~/.config/nixpkgs/config.nix. You must force nixpkgs to not use the local configuration, by providing a `config` argument to your nixpkgs import, such as:
+Note: if it points to the nixpkgs global configuration file, such as ~/.config/nixpkgs/config.nix. You must force nixpkgs to not use the local configuration, by providing at least a `config` and `overlays` arguments to your nixpkgs import, such as:
 
-import (nixpkgs_path) {{ config = {{}}; }};
+import (nixpkgs_path) {{ config = {{}}; overlays = {{}}; }};
 """.format(repo_name = repository_ctx.name,
            deps_listing = '",\n    "'.join(deps_minus_declared_deps.keys())))
                 
@@ -372,7 +372,7 @@ def nixpkgs_cc_configure(
     """
     if not nix_file and not nix_file_content:
         nix_file_content = """
-          with import <nixpkgs> { config = {}; }; buildEnv {
+          with import <nixpkgs> { config = {}; overlays = []; }; buildEnv {
             name = "bazel-cc-toolchain";
             paths = [ stdenv.cc binutils ];
           }

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import ./nixpkgs.nix {} }:
+{ pkgs ? import ./nixpkgs.nix { config = {}; } }:
 
 with pkgs;
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import ./nixpkgs.nix { config = {}; } }:
+{ pkgs ? import ./nixpkgs.nix { config = {}; overlays = []; } }:
 
 with pkgs;
 

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -1,3 +1,3 @@
 with import ./pkgname.nix;
-let pkgs = import <nixpkgs> { config = {}; }; in builtins.getAttr pkgname pkgs
+let pkgs = import <nixpkgs> { config = {}; overlays = []; }; in builtins.getAttr pkgname pkgs
 

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -1,3 +1,3 @@
 with import ./pkgname.nix;
-let pkgs = import <nixpkgs> {}; in builtins.getAttr pkgname pkgs
+let pkgs = import <nixpkgs> { config = {}; }; in builtins.getAttr pkgname pkgs
 

--- a/tests/nixpkgs.nix
+++ b/tests/nixpkgs.nix
@@ -1,1 +1,1 @@
-import <nixpkgs> { config = {}; }
+import <nixpkgs> { config = {}; overlays = []; }

--- a/tests/nixpkgs.nix
+++ b/tests/nixpkgs.nix
@@ -1,1 +1,1 @@
-import <nixpkgs> {}
+import <nixpkgs> { config = {}; }

--- a/tests/output.nix
+++ b/tests/output.nix
@@ -1,4 +1,4 @@
-with import <nixpkgs> {};
+with import <nixpkgs> { config = {}; };
 
 runCommand "some-output" {
   preferLocalBuild = true;

--- a/tests/output.nix
+++ b/tests/output.nix
@@ -1,4 +1,4 @@
-with import <nixpkgs> { config = {}; };
+with import <nixpkgs> { config = {}; overlays = []; };
 
 runCommand "some-output" {
   preferLocalBuild = true;


### PR DESCRIPTION
*This is a breaking change*

By default, nixpkgs will read a global configuration file, by default
`~/.config/nixpkgs/config.nix`. This leads to reproducibility issues
if the configuration is different between users of the repository.

Users  of `nixpkgs_packages` must set the `nix_file_deps` argument
with all the files used by the nix process.

We were previously accepting a global nixpkgs configuration file as
implicit dependency, but this commit now disallow that. User must
explicitly set its own nixpkgs configuration, such as:

```
import nixpkgs_path { config = {}; };
```