### PR TITLE
Fix nix_file_deps on nixpkgs_local_repository

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,6 +20,7 @@ nixpkgs_git_repository(
 nixpkgs_local_repository(
     name = "nixpkgs",
     nix_file = "//:nixpkgs.nix",
+    nix_file_deps = ["//:nixpkgs.json"],
 )
 
 nixpkgs_package(
@@ -39,6 +40,7 @@ nixpkgs_package(
     nix_file_content = "let pkgs = import <nixpkgs> { config = {}; overlays = []; }; in pkgs.hello",
     # Deliberately not @nixpkgs, to test whether explict file works.
     repositories = {"nixpkgs": "//:nixpkgs.nix"},
+    nix_file_deps = ["//:nixpkgs.json"],
 )
 
 nixpkgs_package(
@@ -101,6 +103,7 @@ nixpkgs_package(
     attribute_path = "hello",
     nix_file = "//tests:relative_imports.nix",
     nix_file_deps = [
+        "//:nixpkgs.json",
         "//:nixpkgs.nix",
         "//tests:relative_imports/nixpkgs.nix",
     ],

--- a/nixpkgs.json
+++ b/nixpkgs.json
@@ -1,0 +1,8 @@
+{
+  "owner": "NixOS",
+  "repo": "nixpkgs-channels",
+  "branch": "nixpkgs-unstable",
+  "rev": "0620e0fdbf4d79df771afd28f741b2159f381d2b",
+  "sha256": "046l2c83s568c306hnm8nfdpdhmgnbzgid354hr7p0khq3jx3lhf"
+}
+

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,10 +1,9 @@
 let
   # nixpkgs-unstable as of 2019-04-25
-  nixpkgsRev = "0620e0fdbf4";
-  nixpkgsSha256 = "046l2c83s568c306hnm8nfdpdhmgnbzgid354hr7p0khq3jx3lhf";
+  spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
-    url = "https://github.com/nixos/nixpkgs/archive/${nixpkgsRev}.tar.gz";
-    sha256 = nixpkgsSha256;
+    url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
+    sha256 = spec.sha256;
   };
 in
 import nixpkgs

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -38,12 +38,14 @@ def _nixpkgs_local_repository_impl(repository_ctx):
         )
         target = repository_ctx.path("default.nix")
     else:
-        target = repository_ctx.path(repository_ctx.attr.nix_file)
-        _cp(repository_ctx, target, target.basename)
+        target = _cp(repository_ctx, repository_ctx.attr.nix_file)
+
+    for dep in repository_ctx.attr.nix_file_deps:
+        _cp(repository_ctx, dep)
 
     # Make "@nixpkgs" (syntactic sugar for "@nixpkgs//:nixpkgs") a valid
     # label for the target Nix file.
-    repository_ctx.symlink(target.basename, repository_ctx.name)
+    repository_ctx.symlink(target, repository_ctx.name)
 
 nixpkgs_local_repository = repository_rule(
     implementation = _nixpkgs_local_repository_impl,


### PR DESCRIPTION
Instances of `nixpkgs_local_repository` using `nix_file_deps` and `import`ing addtional files failed with `No such file or directory`. This is a regression introduced by https://github.com/tweag/rules_nixpkgs/commit/54f331937f6d9a59f7afc0523f0b1ab2df57d859, similar to https://github.com/tweag/rules_nixpkgs/pull/91. The reason is that only the file listed in `nix_file` was copied into the repository root, but `nix_file_deps` was ignored.

This PR fixes that by copying the files listed in `nix_file_deps` as well. Additionaly, it preserves the relative path of `nix_file` to the repository root, to ensure that relative imports across directories work.

This PR adds a regression test by making `nixpkgs.nix` depend on an additional file (`nixpkgs.json` declaring the `nixpkgs` version in JSON format).