### PR TITLE
Define nixpkgs_unix_configure

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -124,9 +124,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_sh",
-    sha256 = "ad72710293db59986e1400d70944b3a13a52a11ce411969634669fc545e06c2f",
-    strip_prefix = "rules_sh-5aaea6d44c1ff1ccefc9ec4a22acef301af8f90a",
-    urls = ["https://github.com/tweag/rules_sh/archive/5aaea6d44c1ff1ccefc9ec4a22acef301af8f90a.tar.gz"],
+    sha256 = "2613156e96b41fe0f91ac86a65edaea7da910b7130f2392ca02e8270f674a734",
+    strip_prefix = "rules_sh-0.1.0",
+    urls = ["https://github.com/tweag/rules_sh/archive/v0.1.0.tar.gz"],
 )
 
 load("@rules_sh//sh:repositories.bzl", "rules_sh_dependencies")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,8 +6,8 @@ load(
     "nixpkgs_git_repository",
     "nixpkgs_local_repository",
     "nixpkgs_package",
-    "nixpkgs_posix_configure",
     "nixpkgs_python_configure",
+    "nixpkgs_sh_posix_configure",
 )
 
 # For tests
@@ -133,7 +133,7 @@ load("@rules_sh//sh:repositories.bzl", "rules_sh_dependencies")
 
 rules_sh_dependencies()
 
-nixpkgs_posix_configure(repository = "@nixpkgs")
+nixpkgs_sh_posix_configure(repository = "@nixpkgs")
 
 load("@rules_sh//sh:posix.bzl", "sh_posix_configure")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,6 +6,7 @@ load(
     "nixpkgs_git_repository",
     "nixpkgs_local_repository",
     "nixpkgs_package",
+    "nixpkgs_posix_configure",
     "nixpkgs_python_configure",
 )
 
@@ -118,3 +119,22 @@ nixpkgs_package(
 nixpkgs_cc_configure(repository = "@remote_nixpkgs")
 
 nixpkgs_python_configure(repository = "@remote_nixpkgs")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_sh",
+    sha256 = "ad72710293db59986e1400d70944b3a13a52a11ce411969634669fc545e06c2f",
+    strip_prefix = "rules_sh-5aaea6d44c1ff1ccefc9ec4a22acef301af8f90a",
+    urls = ["https://github.com/tweag/rules_sh/archive/5aaea6d44c1ff1ccefc9ec4a22acef301af8f90a.tar.gz"],
+)
+
+load("@rules_sh//sh:repositories.bzl", "rules_sh_dependencies")
+
+rules_sh_dependencies()
+
+nixpkgs_posix_configure(repository = "@nixpkgs")
+
+load("@rules_sh//sh:posix.bzl", "sh_posix_configure")
+
+sh_posix_configure()

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -431,6 +431,130 @@ def nixpkgs_python_configure(
     )
     native.register_toolchains("@%s//:toolchain" % name)
 
+def nixpkgs_posix_config(name, packages, **kwargs):
+    nixpkgs_package(
+        name = name,
+        nix_file_content = """
+with import <nixpkgs> {{ config = {{}}; overlays = []; }};
+
+let
+  # `packages` might include lists, e.g. `stdenv.initialPath` is a list itself,
+  # so we need to flatten `packages`.
+  flatten = builtins.concatMap (x: if builtins.isList x then x else [x]);
+  env = buildEnv {{
+    name = "posix-toolchain";
+    paths = flatten [ {} ];
+  }};
+  cmd_glob = "${{env}}/bin/*";
+  os = if stdenv.isDarwin then "osx" else "linux";
+in
+
+runCommand "bazel-nixpkgs-posix-toolchain"
+  {{ executable = false;
+    # Pointless to do this on a remote machine.
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+  }}
+  ''
+    n=$out/nixpkgs_posix.bzl
+    mkdir -p "$(dirname "$n")"
+
+    cat >>$n <<EOF
+    load("@rules_sh//sh:posix.bzl", "posix", "sh_posix_toolchain")
+    discovered = {{
+    EOF
+    for cmd in ${{cmd_glob}}; do
+        if [[ -x $cmd ]]; then
+            echo "    '$(basename $cmd)': '$cmd'," >>$n
+        fi
+    done
+    cat >>$n <<EOF
+    }}
+    def create_posix_toolchain():
+        sh_posix_toolchain(
+            name = "nixpkgs_posix",
+            **{{
+                cmd: discovered[cmd]
+                for cmd in posix.commands
+                if cmd in discovered
+            }}
+        )
+    EOF
+  ''
+""".format(" ".join(packages)),
+        build_file_content = """
+load("//:nixpkgs_posix.bzl", "create_posix_toolchain")
+create_posix_toolchain()
+""",
+        **kwargs
+    )
+
+def _nixpkgs_posix_toolchain_impl(repository_ctx):
+    cpu = get_cpu_value(repository_ctx)
+    repository_ctx.file("BUILD", executable = False, content = """
+toolchain(
+    name = "nixpkgs_posix_toolchain",
+    toolchain = "@{workspace}//:nixpkgs_posix",
+    toolchain_type = "@rules_sh//sh/posix:toolchain_type",
+    exec_compatible_with = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:{os}",
+        "@io_tweag_rules_nixpkgs//nixpkgs/constraints:nixpkgs",
+    ],
+    target_compatible_with = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:{os}",
+    ],
+)
+    """.format(
+        workspace = repository_ctx.attr.workspace,
+        os = {"darwin": "osx"}.get(cpu, "linux"),
+    ))
+
+_nixpkgs_posix_toolchain = repository_rule(
+    _nixpkgs_posix_toolchain_impl,
+    attrs = {
+        "workspace": attr.string(),
+    },
+)
+
+def nixpkgs_posix_configure(
+        name = "nixpkgs_posix_config",
+        packages = ["stdenv.initialPath"],
+        **kwargs):
+    """Create a POSIX toolchain from nixpkgs.
+
+    Loads the given Nix packages, scans them for standard Unix tools, and
+    generates a corresponding `sh_posix_toolchain`.
+
+    Make sure to call `nixpkgs_posix_configure` before `sh_posix_configure`,
+    if you use both. Otherwise, the local toolchain will always be chosen in
+    favor of the nixpkgs one.
+
+    Args:
+      name: Name prefix for the generated repositories.
+      packages: List of Nix attribute paths to draw Unix tools from.
+      nix_file_deps: See nixpkgs_package.
+      repositories: See nixpkgs_package.
+      repository: See nixpkgs_package.
+      nixopts: See nixpkgs_package.
+      fail_not_supported: See nixpkgs_package.
+    """
+    nixpkgs_posix_config(
+        name = name,
+        packages = packages,
+        **kwargs
+    )
+
+    # The indirection is required to avoid errors when `nix-build` is not in `PATH`.
+    _nixpkgs_posix_toolchain(
+        name = name + "_toolchain",
+        workspace = name,
+    )
+    native.register_toolchains(
+        "@{}//:nixpkgs_posix_toolchain".format(name + "_toolchain"),
+    )
+
 def _execute_or_fail(repository_ctx, arguments, failure_message = "", *args, **kwargs):
     """Call repository_ctx.execute() and fail if non-zero return code."""
     result = repository_ctx.execute(arguments, *args, **kwargs)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -65,3 +65,17 @@ py_test(
     python_version = "PY3",
     srcs_version = "PY3",
 )
+
+# Test nixpkgs_posix_configure() checking that Unix commands are in Nix store.
+sh_test(
+    name = "run-test-posix-toolchain",
+    timeout = "short",
+    srcs = ["test_posix_toolchain.sh"],
+    args = [
+        "$(POSIX_AWK)",
+        "$(POSIX_CAT)",
+        "$(POSIX_GREP)",
+        "$(POSIX_MAKE)",
+    ],
+    toolchains = ["@rules_sh//sh/posix:make_variables"],
+)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -66,7 +66,7 @@ py_test(
     srcs_version = "PY3",
 )
 
-# Test nixpkgs_posix_configure() checking that Unix commands are in Nix store.
+# Test nixpkgs_sh_posix_configure() checking that Unix commands are in Nix store.
 sh_test(
     name = "run-test-posix-toolchain",
     timeout = "short",

--- a/tests/test_posix_toolchain.sh
+++ b/tests/test_posix_toolchain.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+fail=0
+for cmd in "$@"; do
+  if [[ ! "$cmd" = /nix/store/* ]]; then
+    echo "ERROR: '$cmd' is not in the Nix store." >&2
+    fail=1
+  fi
+done
+exit $fail


### PR DESCRIPTION
Adds `rules_sh` support with `nixpkgs_unix_configure`, a macro to generate a Unix toolchain with commands provided by Nix.

- Update Bazel to version 1.0.0
    `rules_sh` uses the `configure` attribute to `repository_rule` which was only introduced in Bazel 0.29.
- Define `nixpkgs` constraint
    This is intended to move the `nixpkgs` platform constraint defined in `rules_haskell` into `rules_nixpkgs` so that it can be shared. It is used by `nixpkgs_unix_configure` in the `exec_compatible_with` attribute of the generated toolchain.
- Define `nixpkgs_unix_configure`
    This uses `rules_sh`. However, users of `rules_nixpkgs` will only need to depend on `rules_sh` if they use this macro. Otherwise, `rules_nixpkgs` does not depend on `rules_sh`.
- Add tests for `nixpkgs_unix_configure`
    This adds a dependency on `rules_sh` for the test-suite.