### PR TITLE
Add cacert to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,7 @@ with pkgs;
 mkShell {
   buildInputs = [
     bazel
+    cacert
     gcc
     nix
   ];


### PR DESCRIPTION
Otherwise I get build failures like the following in a pure nix shell:

```
$ nix-shell --pure --run 'bazel build @hello//...'
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
ERROR: Traceback (most recent call last):
        File "/home/aj/tweag.io/da/bazel-projects/rules_nixpkgs/nixpkgs/nixpkgs.bzl", line 152
                _execute_or_fail(repository_ctx, nix_build, failure_m...), ...)
        File "/home/aj/tweag.io/da/bazel-projects/rules_nixpkgs/nixpkgs/nixpkgs.bzl", line 321, in _execute_or_fail
                fail("\n{failure_message}\nCommand: {...))

Cannot build Nix attribute ''.
Command: [/nix/store/zw52rvbzhh6x447yc0hn3w7s0wmcq3pw-nix-2.2.2/bin/nix-build, "-E", "import <nixpkgs> { config = {}; overlays = []; }", "-A", "hello", "--out-link", "bazel-support/nix-out-link", "-I", "nixpkgs=/home/aj/.cache/bazel/_bazel_aj/cf7431ac3fb5fc6f4c6a5569d7b55e4a/external/nixpkgs/nixpkgs"]
Return code: 1
Error output:
warning: unable to download 'https://nix-cache.da-ext.net/y7h98qy0j8v4vp56vlk5948f165v8rz1.narinfo': SSL peer certificate or SSH remote key was not OK (60); retrying in 308 ms
warning: unable to download 'https://nix-cache.da-ext.net/y7h98qy0j8v4vp56vlk5948f165v8rz1.narinfo': SSL peer certificate or SSH remote key was not OK (60); retrying in 512 ms
warning: unable to download 'https://nix-cache.da-ext.net/y7h98qy0j8v4vp56vlk5948f165v8rz1.narinfo': SSL peer certificate or SSH remote key was not OK (60); retrying in 1264 ms
warning: unable to download 'https://nix-cache.da-ext.net/y7h98qy0j8v4vp56vlk5948f165v8rz1.narinfo': SSL peer certificate or SSH remote key was not OK (60); retrying in 2354 ms
warning: unable to download 'https://nix-cache.da-ext.net/y7h98qy0j8v4vp56vlk5948f165v8rz1.narinfo': SSL peer certificate or SSH remote key was not OK (60); retrying in 4059 ms
warning: unable to download 'https://nix-cache.da-ext.net/y7h98qy0j8v4vp56vlk5948f165v8rz1.narinfo': SSL peer certificate or SSH remote key was not OK (60); retrying in 8211 ms
warning: unable to download 'https://nix-cache.da-ext.net/y7h98qy0j8v4vp56vlk5948f165v8rz1.narinfo': SSL peer certificate or SSH remote key was not OK (60); retrying in 17114 ms
error: unable to download 'https://nix-cache.da-ext.net/y7h98qy0j8v4vp56vlk5948f165v8rz1.narinfo': SSL peer certificate or SSH remote key was not OK (60)
```