### PR TITLE
Adds nixpkgs_python_configure

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/constraints:linux_x86_64_nixpkgs

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,6 +6,7 @@ load(
     "nixpkgs_git_repository",
     "nixpkgs_local_repository",
     "nixpkgs_package",
+    "nixpkgs_python_configure",
 )
 
 # For tests
@@ -115,3 +116,5 @@ nixpkgs_package(
 )
 
 nixpkgs_cc_configure(repository = "@remote_nixpkgs")
+
+nixpkgs_python_configure(repository = "@remote_nixpkgs")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,9 +38,9 @@ nixpkgs_package(
 nixpkgs_package(
     name = "expr-test",
     nix_file_content = "let pkgs = import <nixpkgs> { config = {}; overlays = []; }; in pkgs.hello",
+    nix_file_deps = ["//:nixpkgs.json"],
     # Deliberately not @nixpkgs, to test whether explict file works.
     repositories = {"nixpkgs": "//:nixpkgs.nix"},
-    nix_file_deps = ["//:nixpkgs.json"],
 )
 
 nixpkgs_package(
@@ -81,8 +81,12 @@ nixpkgs_package(
     nix_file_content = """
 { packagePath }: (import <nixpkgs> { config = {}; overlays = []; }).${packagePath}
     """,
+    nixopts = [
+        "--argstr",
+        "packagePath",
+        "hello",
+    ],
     repository = "@nixpkgs",
-    nixopts = ["--argstr", "packagePath", "hello"],
 )
 
 nixpkgs_package(

--- a/nixpkgs.json
+++ b/nixpkgs.json
@@ -2,7 +2,6 @@
   "owner": "NixOS",
   "repo": "nixpkgs-channels",
   "branch": "nixpkgs-unstable",
-  "rev": "0620e0fdbf4d79df771afd28f741b2159f381d2b",
-  "sha256": "046l2c83s568c306hnm8nfdpdhmgnbzgid354hr7p0khq3jx3lhf"
+  "rev": "1ee040724a417d9e6e8e28dfd88a0c8c35070689",
+  "sha256": "0r8dv6p1vhxzv50j50bjvwrq5wi9sg35nkm12ga25pw1lzvv6yr9"
 }
-

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,5 +1,5 @@
 let
-  # nixpkgs-unstable as of 2019-04-25
+  # nixpkgs-unstable as of 2019-11-17
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/nixpkgs/constraints/BUILD.bazel
+++ b/nixpkgs/constraints/BUILD.bazel
@@ -1,0 +1,25 @@
+constraint_value(
+    name = "nixpkgs",
+    constraint_setting = "@bazel_tools//tools/cpp:cc_compiler",
+    visibility = ["//visibility:public"],
+)
+
+platform(
+    name = "linux_x86_64_nixpkgs",
+    constraint_values = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:linux",
+        ":nixpkgs",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+platform(
+    name = "darwin_x86_64_nixpkgs",
+    constraint_values = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:osx",
+        ":nixpkgs",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -65,6 +65,7 @@ def _nixpkgs_package_impl(repository_ctx):
 
     # Is nix supported on this platform?
     not_supported = not _is_supported_platform(repository_ctx)
+
     # Should we fail if Nix is not supported?
     fail_not_supported = repository_ctx.attr.fail_not_supported
 

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -341,8 +341,11 @@ toolchain(
 _nixpkgs_python_toolchain = repository_rule(
     _nixpkgs_python_toolchain_impl,
     attrs = {
-        "python2_runtime": attr.label(),
-        "python3_runtime": attr.label(),
+        # Using attr.string instead of attr.label, so that the repository rule
+        # does not explicitly depend on the nixpkgs_package instances. This is
+        # necessary, so that builds don't fail on platforms without nixpkgs.
+        "python2_runtime": attr.string(),
+        "python3_runtime": attr.string(),
     },
 )
 
@@ -496,7 +499,7 @@ def _cp(repository_ctx, src, dest = None):
 
 def _label_string(label):
     """Convert the given (optional) Label to a string."""
-    if label == None:
+    if not label:
         return "None"
     else:
         return '"%s"' % label

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -57,3 +57,11 @@ cc_binary(
     name = "cc-test",
     srcs = ["cc-test.cc"],
 )
+
+# Test nixpkgs_python_configure() by running some Python code.
+py_test(
+    name = "python-test",
+    srcs = ["python-test.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+)

--- a/tests/python-test.py
+++ b/tests/python-test.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+_failure_message = """\
+Python interpreter is not provided by the toolchain.
+Expected: '{expected}'
+Actual:   '{actual}'.
+"""
+
+if __name__ == "__main__":
+    runfiles_dir = os.environ["RUNFILES_DIR"]
+    python_bin = os.path.join(
+        runfiles_dir, "nixpkgs_python_toolchain_python3", "bin", "python")
+    if not sys.executable == python_bin:
+        print(_failure_message.format(
+            expected = python_bin,
+            actual = sys.executable,
+        ), file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
- Define nixpkgs constraint
This is intended to move the nixpkgs platform constraint defined in rules_haskell into rules_nixpkgs so that it can be shared. It is used by nixpkgs_unix_configure in the exec_compatible_with attribute of the generated toolchain.
- Update Bazel to version 1.1.0
    The update to Bazel 1.1.0 on rules_haskell (anything >0.29 really) motivates the introduction of `nixpkgs_python_configure`. See https://github.com/tweag/rules_haskell/pull/1142.
- Add `nixpkgs_python_configure`
    > Define and register a Python toolchain provided by nixpkgs.
    Creates `nixpkgs_package`s for Python 2 or 3 `py_runtime` instances and a
    corresponding `py_runtime_pair` and `toolchain`. The toolchain is
    automatically registered and uses the constraint:
      "@io_tweag_rules_nixpkgs//nixpkgs/constraints:nixpkgs"
- Adds a test-case for `nixpkgs_python_configure`.

This PR takes the definition of the `nixpkgs` constraint and the Bazel update out of #95. It should take precedence, as `nixpkgs_python_configure` is required to update Bazel in rules_haskell, which in turn is required to use `nixpkgs_unix_configure` in rules_haskell.