### PR TITLE
Fail when nixpkgs_package output is a single file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,6 +116,20 @@ nixpkgs_package(
     repository = "@nixpkgs",
 )
 
+# This bazel build @output-derivation-is-a-file//... must fail
+# See https://github.com/tweag/rules_nixpkgs/issues/99 for details
+nixpkgs_package(
+    name = "output-derivation-is-a-file",
+    attribute_path = "",
+    nix_file_content = """let pkgs = import <nixpkgs> { config = {}; overlays = []; }; in pkgs.writeText "foo" "bar" """,
+    nix_file_deps = [
+        "//:nixpkgs.json",
+        "//:nixpkgs.nix",
+        "//tests:relative_imports/nixpkgs.nix",
+    ],
+    repository = "@nixpkgs",
+)
+
 nixpkgs_cc_configure(repository = "@remote_nixpkgs")
 
 nixpkgs_python_configure(repository = "@remote_nixpkgs")

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -163,7 +163,7 @@ def _nixpkgs_package_impl(repository_ctx):
         # ensure that the output is a directory
         test_path = repository_ctx.which("test")
         _execute_or_fail(repository_ctx, [test_path, "-d", output_path],
-                         failure_message = "nixpkgs_package '@{}' outputs a single file which is not supported by rule_nixpkgs. Please only use directory.".format(
+                         failure_message = "nixpkgs_package '@{}' outputs a single file which is not supported by rules_nixpkgs. Please only use directories.".format(
                              repository_ctx.name
                          ),
         )

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -160,6 +160,14 @@ def _nixpkgs_package_impl(repository_ctx):
         )
         output_path = exec_result.stdout.splitlines()[-1]
 
+        # ensure that the output is a directory
+        test_path = repository_ctx.which("test")
+        _execute_or_fail(repository_ctx, [test_path, "-d", output_path],
+                         failure_message = "nixpkgs_package '@{}' outputs a single file which is not supported by rule_nixpkgs. Please only use directory.".format(
+                             repository_ctx.name
+                         ),
+        )
+
         # Build a forest of symlinks (like new_local_package() does) to the
         # Nix store.
         for target in _find_children(repository_ctx, output_path):


### PR DESCRIPTION
This closes #99.

Currently we do not support single file as bazel external repository.
However if user try it by mistake it fails with "could not create
symlink, file already exists".

This change introduces a more detailled error.