### PR TITLE
Use platforms repo for constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 [Unreleased]: https://github.com/tweag/rules_nixpkgs/compare/v0.6.0...HEAD
 
+### Added
+
+- Define `rules_nixpkgs_dependencies` in `//nixpkgs:repositories.bzl`.
+
 ## [0.6.0] - 2019-11-14
 
 [0.6.0]: https://github.com/tweag/rules_nixpkgs/compare/v0.5.2...0.6.0

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ http_archive(
     urls = ["https://github.com/tweag/rules_nixpkgs/archive/$COMMIT.tar.gz"],
 )
 
+load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
+rules_nixpkgs_dependencies()
+
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository", "nixpkgs_package")
 ```
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,9 @@
 workspace(name = "io_tweag_rules_nixpkgs")
 
+load("//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
+
+rules_nixpkgs_dependencies()
+
 load(
     "//nixpkgs:nixpkgs.bzl",
     "nixpkgs_cc_configure",

--- a/nixpkgs/constraints/BUILD.bazel
+++ b/nixpkgs/constraints/BUILD.bazel
@@ -7,8 +7,8 @@ constraint_value(
 platform(
     name = "linux_x86_64_nixpkgs",
     constraint_values = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:linux",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
         ":nixpkgs",
     ],
     visibility = ["//visibility:public"],
@@ -17,8 +17,8 @@ platform(
 platform(
     name = "darwin_x86_64_nixpkgs",
     constraint_values = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:osx",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:osx",
         ":nixpkgs",
     ],
     visibility = ["//visibility:public"],

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -331,13 +331,13 @@ toolchain(
     toolchain = ":py_runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
     exec_compatible_with = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:{os}",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:{os}",
         "@io_tweag_rules_nixpkgs//nixpkgs/constraints:nixpkgs",
     ],
     target_compatible_with = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:{os}",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:{os}",
     ],
 )
 """.format(
@@ -505,13 +505,13 @@ toolchain(
     toolchain = "@{workspace}//:nixpkgs_sh_posix",
     toolchain_type = "@rules_sh//sh/posix:toolchain_type",
     exec_compatible_with = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:{os}",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:{os}",
         "@io_tweag_rules_nixpkgs//nixpkgs/constraints:nixpkgs",
     ],
     target_compatible_with = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:{os}",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:{os}",
     ],
 )
     """.format(

--- a/nixpkgs/repositories.bzl
+++ b/nixpkgs/repositories.bzl
@@ -1,0 +1,12 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def rules_nixpkgs_dependencies():
+    """Load repositories required by rules_nixpkgs."""
+    maybe(
+        http_archive,
+        "platforms",
+        sha256 = "23566db029006fe23d8140d14514ada8c742d82b51973b4d331ee423c75a0bfa",
+        strip_prefix = "platforms-46993efdd33b73649796c5fc5c9efb193ae19d51",
+        urls = ["https://github.com/bazelbuild/platforms/archive/46993efdd33b73649796c5fc5c9efb193ae19d51.tar.gz"],
+    )


### PR DESCRIPTION
See https://github.com/tweag/rules_haskell/pull/1196

- Uses `@platforms//<setting>:<value>` instead of `@bazel_tools//platforms:<value>`.
- Adds `rules_nixpkgs_dependencies` to `@rules_nixpkgs//repositories.bzl`.
- Loads `@platforms` in `rules_nixpkgs_dependencies`. In principle `@platforms` is builtin, but the docs say it's preferred to explicitly import the repository.
