### PR TITLE
Update to Bazel 2.1

### DIFF
--- a/nixpkgs.json
+++ b/nixpkgs.json
@@ -2,6 +2,6 @@
   "owner": "NixOS",
   "repo": "nixpkgs-channels",
   "branch": "nixpkgs-unstable",
-  "rev": "1ee040724a417d9e6e8e28dfd88a0c8c35070689",
-  "sha256": "0r8dv6p1vhxzv50j50bjvwrq5wi9sg35nkm12ga25pw1lzvv6yr9"
+  "rev": "6b6f9d769a5086df38a06b680104d0c5fd1a8e0e",
+  "sha256": "1pc6ypxas76i2l2dhr58bml2f0hmgz8py0d8zylwivhs6zg9fcgs"
 }

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,5 +1,5 @@
 let
-  # nixpkgs-unstable as of 2019-11-17
+  # nixpkgs-unstable as of 2020-03-09
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/nixpkgs/constraints/BUILD.bazel
+++ b/nixpkgs/constraints/BUILD.bazel
@@ -9,7 +9,7 @@ platform(
     constraint_values = [
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
-        ":nixpkgs",
+        "@io_tweag_rules_nixpkgs//nixpkgs/constraints:nixpkgs",
     ],
     visibility = ["//visibility:public"],
 )
@@ -19,7 +19,7 @@ platform(
     constraint_values = [
         "@platforms//cpu:x86_64",
         "@platforms//os:osx",
-        ":nixpkgs",
+        "@io_tweag_rules_nixpkgs//nixpkgs/constraints:nixpkgs",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
* Updates the nixpkgs revision used for the Nix shell to the latest of nixpkgs-unstable.
* As pointed out by @regnat [here](https://github.com/tweag/rules_nixpkgs/pull/107#issuecomment-596402385) there was an issue with the Python toolchain tests failing. The reason seems to be an issue in Bazel where it considers `//nixpkgs/constraints:nixpkgs` and `@io_tweag_rules_nixpkgs//nixpkgs/constraints:nixpkgs` two different values, even though they refer to the same target.