### PR TITLE
Add git to the nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,5 +8,6 @@ mkShell {
     cacert
     gcc
     nix
+    git
   ];
 }


### PR DESCRIPTION
Apparently needed after the update to bazel 2.1 to fetch some dependencies

(and not caught by local testing because these were already cached locally)