### PR TITLE
Adapt to change in sh_posix_toolchain prototype

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -151,9 +151,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_sh",
-    sha256 = "2613156e96b41fe0f91ac86a65edaea7da910b7130f2392ca02e8270f674a734",
-    strip_prefix = "rules_sh-0.1.0",
-    urls = ["https://github.com/tweag/rules_sh/archive/v0.1.0.tar.gz"],
+    sha256 = "83a065ba6469135a35786eb741e17d50f360ca92ab2897857475ab17c0d29931",
+    strip_prefix = "rules_sh-0.2.0",
+    urls = ["https://github.com/tweag/rules_sh/archive/v0.2.0.tar.gz"],
 )
 
 load("@rules_sh//sh:repositories.bzl", "rules_sh_dependencies")

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -504,7 +504,7 @@ runCommand "bazel-nixpkgs-posix-toolchain"
     def create_posix_toolchain():
         sh_posix_toolchain(
             name = "nixpkgs_sh_posix",
-            **{{
+            cmds = {{
                 cmd: discovered[cmd]
                 for cmd in posix.commands
                 if cmd in discovered


### PR DESCRIPTION
This PR adapts `rules_nixpkgs` to this change in `rules_sh`: https://github.com/tweag/rules_sh/pull/14

To test this change, you need to apply the following patch to the WORKSPACE file:

```patch
@@ -151,9 +151,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_sh",
-    sha256 = "2613156e96b41fe0f91ac86a65edaea7da910b7130f2392ca02e8270f674a734",
-    strip_prefix = "rules_sh-0.1.0",
-    urls = ["https://github.com/tweag/rules_sh/archive/v0.1.0.tar.gz"],
+    strip_prefix = "rules_sh-a9adce31cd6aed94152cc6e580e03004f7d29552",
+    urls = ["https://github.com/tweag/rules_sh/archive/a9adce31cd6aed94152cc6e580e03004f7d29552.tar.gz"],
 )
```