### PR TITLE
Flip back to verbose output in nixpkgs_package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Define `rules_nixpkgs_dependencies` in `//nixpkgs:repositories.bzl`.
 - Define `nixpkgs_go_configure` in `//nixpkgs:toolchains/go.bzl`
+- `nixpkgs_package` now has a `quiet` attribute.
+
+### Changed
+
+- Show Nix output by default, like in releases prior to v0.6.
 
 ## [0.6.0] - 2019-11-14
 

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -162,6 +162,7 @@ def _nixpkgs_package_impl(repository_ctx):
             failure_message = "Cannot build Nix attribute '{}'.".format(
                 repository_ctx.attr.attribute_path,
             ),
+            quiet = False,
             timeout = timeout,
         )
         output_path = exec_result.stdout.splitlines()[-1]

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -162,7 +162,7 @@ def _nixpkgs_package_impl(repository_ctx):
             failure_message = "Cannot build Nix attribute '{}'.".format(
                 repository_ctx.attr.attribute_path,
             ),
-            quiet = False,
+            quiet = repository_ctx.attr.quiet,
             timeout = timeout,
         )
         output_path = exec_result.stdout.splitlines()[-1]
@@ -202,6 +202,7 @@ _nixpkgs_package = repository_rule(
         "build_file": attr.label(),
         "build_file_content": attr.string(),
         "nixopts": attr.string_list(),
+        "quiet": attr.bool(),
         "fail_not_supported": attr.bool(default = True, doc = """
             If set to True (default) this rule will fail on platforms which do not support Nix (e.g. Windows). If set to False calling this rule will succeed but no output will be generated.
                                         """),


### PR DESCRIPTION
Historically, the user was able to see the output of `nix-build` in
real-time. This was useful, because building derivations can take
a long time. Even if the binary cache can be used for all derivations,
downloading can take a long time. Then #77 came along, which made
`nix-build` quiet as a side-effect. Later, #86 subsumed #77 with
a simpler implementation. However, people argued in #82 that being
quiet is the right thing to do, because otherwise workspace rule
output can garble the output of `bazel query` and break scripts. So we
stuck to quiet output and this was called out in the v0.6 changelog.

It turns out that the problem affects other rule authors too (see
bazelbuild/rules_nodejs#583). This led to bazelbuild/bazel#10611,
which fixes the problem for everyone, and shipped in Bazel 3.0. Now,
all workspace rule output goes to `stderr`, so scripts calling `bazel
query` shouldn't be affected.

Given this upstream change, my position is that being verbose is now
the right thing to do. If #85 is implemented, then being verbose
should remain the default, at least for users of Bazel 3.0 onwards.
Because even small packages may have a large set of dependencies that
must be downloaded first. It's nigh impossible for the author of the
workspace file to anticipate the state of the user's cache.