### PR TITLE
New configuration setting and platform

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,1 @@
-build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/constraints:linux_x86_64_nixpkgs
+build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- The constraint value for targets to detect whether Nix is available
+  on the current platform is now called
+  `@//nixpkgs/constraints:support_nix`. The associated constraint
+  setting is `@//nixpkgs/constraints:nix`. The old constraint
+  `@//nixpkgs/constraints:nixpkgs` constraint setting is still
+  available. But it is highly recommended to migrate to the new
+  constraint setting, and update platform definitions accordingly.
+  This is a breaking change for users of `nixpkgs_python_configure`.
 - Show Nix output by default, like in releases prior to v0.6.
 
 ## [0.6.0] - 2019-11-14

--- a/nixpkgs/constraints/BUILD.bazel
+++ b/nixpkgs/constraints/BUILD.bazel
@@ -1,7 +1,16 @@
+package(default_visibility = ["//visibility:public"])
+
+constraint_setting(name = "nix")
+
+constraint_value(
+    name =  "support_nix",
+    constraint_setting = ":nix",
+)
+
 constraint_value(
     name = "nixpkgs",
     constraint_setting = "@bazel_tools//tools/cpp:cc_compiler",
-    visibility = ["//visibility:public"],
+    deprecation = "Use support_nix constraint value instead.",
 )
 
 platform(

--- a/nixpkgs/constraints/BUILD.bazel
+++ b/nixpkgs/constraints/BUILD.bazel
@@ -20,6 +20,7 @@ platform(
         "@platforms//os:linux",
         "@io_tweag_rules_nixpkgs//nixpkgs/constraints:nixpkgs",
     ],
+    deprecation = "Use @io_tweag_rules_nixpkgs//platforms:host instead.",
     visibility = ["//visibility:public"],
 )
 
@@ -30,5 +31,6 @@ platform(
         "@platforms//os:osx",
         "@io_tweag_rules_nixpkgs//nixpkgs/constraints:nixpkgs",
     ],
+    deprecation = "Use @io_tweag_rules_nixpkgs//platforms:host instead.",
     visibility = ["//visibility:public"],
 )

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -350,7 +350,7 @@ toolchain(
     exec_compatible_with = [
         "@platforms//cpu:x86_64",
         "@platforms//os:{os}",
-        "@io_tweag_rules_nixpkgs//nixpkgs/constraints:nixpkgs",
+        "@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix",
     ],
     target_compatible_with = [
         "@platforms//cpu:x86_64",
@@ -413,7 +413,7 @@ def nixpkgs_python_configure(
     Creates `nixpkgs_package`s for Python 2 or 3 `py_runtime` instances and a
     corresponding `py_runtime_pair` and `toolchain`. The toolchain is
     automatically registered and uses the constraint:
-      "@io_tweag_rules_nixpkgs//nixpkgs/constraints:nixpkgs"
+      "@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix"
 
     Attrs:
       name: The name-prefix for the created external repositories.
@@ -533,7 +533,7 @@ toolchain(
     exec_compatible_with = [
         "@platforms//cpu:x86_64",
         "@platforms//os:{os}",
-        "@io_tweag_rules_nixpkgs//nixpkgs/constraints:nixpkgs",
+        "@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix",
     ],
     target_compatible_with = [
         "@platforms//cpu:x86_64",

--- a/nixpkgs/platforms/BUILD.bazel
+++ b/nixpkgs/platforms/BUILD.bazel
@@ -1,0 +1,6 @@
+platform(
+    name = "host",
+    constraint_values = ["@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix"],
+    parents = ["@local_config_platform//:host"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Defines a new constraint setting, constraint value, and platform as
per #121. The existing constraint value and platforms are not removed.
Just deprecated.

Closes #121