### PR TITLE
Include Skylib in repositories()

### DIFF
--- a/nixpkgs/repositories.bzl
+++ b/nixpkgs/repositories.bzl
@@ -10,3 +10,10 @@ def rules_nixpkgs_dependencies():
         strip_prefix = "platforms-46993efdd33b73649796c5fc5c9efb193ae19d51",
         urls = ["https://github.com/bazelbuild/platforms/archive/46993efdd33b73649796c5fc5c9efb193ae19d51.tar.gz"],
     )
+    maybe(
+        http_archive,
+        "bazel_skylib",
+        sha256 = "e5d90f0ec952883d56747b7604e2a15ee36e288bb556c3d0ed33e818a4d971f2",
+        strip_prefix = "bazel-skylib-1.0.2",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/1.0.2.tar.gz"],
+    )


### PR DESCRIPTION
Use the same version as rules_haskell does currently.