### PR TITLE
Allow BUILD.pkg to find more kinds of header files

### DIFF
--- a/nixpkgs/BUILD.pkg
+++ b/nixpkgs/BUILD.pkg
@@ -12,5 +12,6 @@ filegroup(
 
 filegroup(
     name = "include",
-    srcs = glob(["include/**/*.h"], allow_empty = True),
+    srcs = glob(["include/**/*.h", "include/**/*.hh", "include/**/*.hpp", "include/**/*.hxx"], allow_empty = True),
 )
+

--- a/nixpkgs/BUILD.pkg
+++ b/nixpkgs/BUILD.pkg
@@ -14,4 +14,3 @@ filegroup(
     name = "include",
     srcs = glob(["include/**/*.h", "include/**/*.hh", "include/**/*.hpp", "include/**/*.hxx"], allow_empty = True),
 )
-


### PR DESCRIPTION
I hit this building an extension for Ruby, which uses .hpp for some files.