### PR TITLE
Generate API documentation using Stardoc

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,4 +2,8 @@ exports_files([
     "nixpkgs.json",
     "nixpkgs.nix",
 ])
-exports_files(["README.md"], visibility = ["//docs:__subpackages__"])
+
+exports_files(
+    ["README.md"],
+    visibility = ["//docs:__subpackages__"],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,3 +2,4 @@ exports_files([
     "nixpkgs.json",
     "nixpkgs.nix",
 ])
+exports_files(["README.md"], visibility = ["//docs:__subpackages__"])

--- a/README.md
+++ b/README.md
@@ -254,20 +254,10 @@ which tools were discovered.
 
 This rule depends on [`rules_cc`](https://github.com/bazelbuild/rules_cc).
 
-Note:
-  You need to configure `--crosstool_top=@&lt;name&gt;//:toolchain` to activate this
-  toolchain.
+**Note:**
+You need to configure `--crosstool_top=@&lt;name&gt;//:toolchain` to activate
+this toolchain.
 
-Attrs:
-  attribute_path: optional, string, Obtain the toolchain from the Nix expression under this attribute path. Requires `nix_file` or `nix_file_content`.
-  nix_file: optional, Label, Obtain the toolchain from the Nix expression defined in this file. Specify only one of `nix_file` or `nix_file_content`.
-  nix_file_content: optional, string, Obtain the toolchain from the given Nix expression. Specify only one of `nix_file` or `nix_file_content`.
-  nix_file_deps: optional, list of Label, Additional files that the Nix expression depends on.
-  repositories: dict of Label to string, Provides `&lt;nixpkgs&gt;` and other repositories. Specify one of `repositories` or `repository`.
-  repository: Label, Provides `&lt;nixpkgs&gt;`. Specify one of `repositories` or `repository`.
-  nixopts: optional, list of string, Extra flags to pass when calling Nix. Subject to location expansion, any instance of `$(location LABEL)` will be replaced by the path to the file ferenced by `LABEL` relative to the workspace root.
-  quiet: bool, Whether to hide `nix-build` output.
-  fail_not_supported: bool, Whether to fail if `nix-build` is not available.
 
 #### Parameters
 
@@ -293,6 +283,11 @@ default is <code>"local_config_cc"</code>
 optional.
 default is <code>""</code>
 
+<p>
+
+optional, string, Obtain the toolchain from the Nix expression under this attribute path. Requires `nix_file` or `nix_file_content`.
+
+</p>
 </td>
 </tr>
 <tr id="nixpkgs_cc_configure-nix_file">
@@ -302,6 +297,11 @@ default is <code>""</code>
 optional.
 default is <code>None</code>
 
+<p>
+
+optional, Label, Obtain the toolchain from the Nix expression defined in this file. Specify only one of `nix_file` or `nix_file_content`.
+
+</p>
 </td>
 </tr>
 <tr id="nixpkgs_cc_configure-nix_file_content">
@@ -311,6 +311,11 @@ default is <code>None</code>
 optional.
 default is <code>""</code>
 
+<p>
+
+optional, string, Obtain the toolchain from the given Nix expression. Specify only one of `nix_file` or `nix_file_content`.
+
+</p>
 </td>
 </tr>
 <tr id="nixpkgs_cc_configure-nix_file_deps">
@@ -320,6 +325,11 @@ default is <code>""</code>
 optional.
 default is <code>[]</code>
 
+<p>
+
+optional, list of Label, Additional files that the Nix expression depends on.
+
+</p>
 </td>
 </tr>
 <tr id="nixpkgs_cc_configure-repositories">
@@ -329,6 +339,11 @@ default is <code>[]</code>
 optional.
 default is <code>{}</code>
 
+<p>
+
+dict of Label to string, Provides `<nixpkgs>` and other repositories. Specify one of `repositories` or `repository`.
+
+</p>
 </td>
 </tr>
 <tr id="nixpkgs_cc_configure-repository">
@@ -338,6 +353,11 @@ default is <code>{}</code>
 optional.
 default is <code>None</code>
 
+<p>
+
+Label, Provides `<nixpkgs>`. Specify one of `repositories` or `repository`.
+
+</p>
 </td>
 </tr>
 <tr id="nixpkgs_cc_configure-nixopts">
@@ -347,6 +367,11 @@ default is <code>None</code>
 optional.
 default is <code>[]</code>
 
+<p>
+
+optional, list of string, Extra flags to pass when calling Nix. Subject to location expansion, any instance of `$(location LABEL)` will be replaced by the path to the file ferenced by `LABEL` relative to the workspace root.
+
+</p>
 </td>
 </tr>
 <tr id="nixpkgs_cc_configure-quiet">
@@ -356,6 +381,11 @@ default is <code>[]</code>
 optional.
 default is <code>False</code>
 
+<p>
+
+bool, Whether to hide `nix-build` output.
+
+</p>
 </td>
 </tr>
 <tr id="nixpkgs_cc_configure-fail_not_supported">
@@ -365,6 +395,142 @@ default is <code>False</code>
 optional.
 default is <code>True</code>
 
+<p>
+
+bool, Whether to fail if `nix-build` is not available.
+
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+
+<a id="#nixpkgs_cc_configure_deprecated"></a>
+
+### nixpkgs_cc_configure_deprecated
+
+<pre>
+nixpkgs_cc_configure_deprecated(<a href="#nixpkgs_cc_configure_deprecated-repository">repository</a>, <a href="#nixpkgs_cc_configure_deprecated-repositories">repositories</a>, <a href="#nixpkgs_cc_configure_deprecated-nix_file">nix_file</a>, <a href="#nixpkgs_cc_configure_deprecated-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_cc_configure_deprecated-nix_file_content">nix_file_content</a>,
+                                <a href="#nixpkgs_cc_configure_deprecated-nixopts">nixopts</a>)
+</pre>
+
+Use a CC toolchain from Nixpkgs. No-op if not a nix-based platform.
+
+Tells Bazel to use compilers and linkers from Nixpkgs for the CC toolchain.
+By default, Bazel auto-configures a CC toolchain from commands available in
+the environment (e.g. `gcc`). Overriding this autodetection makes builds
+more hermetic and is considered a best practice.
+
+#### Example
+
+  ```bzl
+  nixpkgs_cc_configure(repository = "@nixpkgs//:default.nix")
+  ```
+
+
+#### Parameters
+
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+<tr id="nixpkgs_cc_configure_deprecated-repository">
+<td><code>repository</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+A repository label identifying which Nixpkgs to use.
+  Equivalent to `repositories = { "nixpkgs": ...}`.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure_deprecated-repositories">
+<td><code>repositories</code></td>
+<td>
+
+optional.
+default is <code>{}</code>
+
+<p>
+
+A dictionary mapping `NIX_PATH` entries to repository labels.
+
+  Setting it to
+  ```
+  repositories = { "myrepo" : "//:myrepo" }
+  ```
+  for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) for more information.
+
+  Specify one of `repository` or `repositories`.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure_deprecated-nix_file">
+<td><code>nix_file</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+An expression for a Nix environment derivation.
+  The environment should expose all the commands that make up a CC
+  toolchain (`cc`, `ld` etc). Exposes all commands in `stdenv.cc` and
+  `binutils` by default.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure_deprecated-nix_file_deps">
+<td><code>nix_file_deps</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+Dependencies of `nix_file` if any.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure_deprecated-nix_file_content">
+<td><code>nix_file_content</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+An expression for a Nix environment derivation.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure_deprecated-nixopts">
+<td><code>nixopts</code></td>
+<td>
+
+optional.
+default is <code>[]</code>
+
+<p>
+
+Options to forward to the nix command.
+
+</p>
 </td>
 </tr>
 </tbody>

--- a/README.md
+++ b/README.md
@@ -249,13 +249,13 @@ this rule to specify explicitly which commands the toolchain should use.
 Specifically, it builds a Nix derivation that provides the CC toolchain
 tools in the `bin/` path and constructs a CC toolchain that uses those
 tools. Tools that aren't found are replaced by `${coreutils}/bin/false`.
-You can inspect the resulting `@&lt;name&gt;_info//:CC_TOOLCHAIN_INFO` to see
+You can inspect the resulting `@<name>_info//:CC_TOOLCHAIN_INFO` to see
 which tools were discovered.
 
 This rule depends on [`rules_cc`](https://github.com/bazelbuild/rules_cc).
 
 **Note:**
-You need to configure `--crosstool_top=@&lt;name&gt;//:toolchain` to activate
+You need to configure `--crosstool_top=@<name>//:toolchain` to activate
 this toolchain.
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- Edit docs/README.md.tpl and run `bazel run //docs:update-readme` to change the project README. -->
+
 # Nixpkgs rules for Bazel
 
 [![Build status](https://badge.buildkite.com/79bd0a8aa1e47a92e0254ca3afe5f439776e6d389cfbde9d8c.svg?branch=master)](https://buildkite.com/tweag-1/rules-nixpkgs)
@@ -22,9 +24,12 @@ Links:
 ## Rules
 
 * [nixpkgs_git_repository](#nixpkgs_git_repository)
+* [nixpkgs_local_repository](#nixpkgs_local_repository)
 * [nixpkgs_package](#nixpkgs_package)
 * [nixpkgs_cc_configure](#nixpkgs_cc_configure)
 * [nixpkgs_cc_configure_deprecated](#nixpkgs_cc_configure_deprecated)
+* [nixpkgs_python_configure](#nixpkgs_python_configure)
+* [nixpkgs_sh_posix_configure](#nixpkgs_sh_posix_configure)
 * [nixpkgs_go_configure](#nixpkgs_go_configure)
 
 ## Setup
@@ -46,6 +51,15 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository", "
 load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl", "nixpkgs_go_toolchain") # optional
 ```
 
+If you use `rules_nixpkgs` to configure a toolchain then you will also need to
+configure the build platform to include the
+`@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix` constraint. For
+example by adding the following to `.bazelrc`:
+
+```
+build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
+```
+
 ## Example
 
 ```bzl
@@ -63,271 +77,168 @@ nixpkgs_package(
 
 ## Rules
 
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Rules for importing Nixpkgs packages.
+
+<a id="#nixpkgs_git_repository"></a>
+
 ### nixpkgs_git_repository
+
+<pre>
+nixpkgs_git_repository(<a href="#nixpkgs_git_repository-name">name</a>, <a href="#nixpkgs_git_repository-remote">remote</a>, <a href="#nixpkgs_git_repository-revision">revision</a>, <a href="#nixpkgs_git_repository-sha256">sha256</a>)
+</pre>
 
 Name a specific revision of Nixpkgs on GitHub or a local checkout.
 
-```bzl
-nixpkgs_git_repository(name, revision, sha256)
-```
 
-<table class="table table-condensed table-bordered table-params">
-  <colgroup>
-    <col class="col-param" />
-    <col class="param-description" />
-  </colgroup>
-  <thead>
-    <tr>
-      <th colspan="2">Attributes</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>name</code></td>
-      <td>
-        <p><code>Name; required</code></p>
-        <p>A unique name for this repository.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>revision</code></td>
-      <td>
-        <p><code>String; required</code></p>
-        <p>Git commit hash or tag identifying the version of Nixpkgs
-           to use.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>remote</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>The URI of the remote Git repository. This must be a HTTP
-           URL. There is currently no support for authentication.
-           Defaults to <a href="https://github.com/NixOS/nixpkgs">
-           upstream nixpkgs.</a></p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>sha256</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>The SHA256 used to verify the integrity of the repository.</p>
-      </td>
-    </tr>
-  </tbody>
+#### Attributes
+
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+<tr id="nixpkgs_git_repository-name">
+<td><code>name</code></td>
+<td>
+
+<a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
+
+<p>
+
+A unique name for this repository.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_git_repository-remote">
+<td><code>remote</code></td>
+<td>
+
+String; optional
+
+<p>
+
+The URI of the remote Git repository. This must be a HTTP URL. There is currently no support for authentication. Defaults to [upstream nixpkgs](https://github.com/NixOS/nixpkgs).
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_git_repository-revision">
+<td><code>revision</code></td>
+<td>
+
+String; required
+
+<p>
+
+Git commit hash or tag identifying the version of Nixpkgs to use.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_git_repository-sha256">
+<td><code>sha256</code></td>
+<td>
+
+String; optional
+
+<p>
+
+The SHA256 used to verify the integrity of the repository.
+
+</p>
+</td>
+</tr>
+</tbody>
 </table>
+
+
+<a id="#nixpkgs_local_repository"></a>
 
 ### nixpkgs_local_repository
 
-Create an external repository representing the content of Nixpkgs,
-based on a Nix expression stored locally or provided inline. One of
-`nix_file` or `nix_file_content` must be provided.
+<pre>
+nixpkgs_local_repository(<a href="#nixpkgs_local_repository-name">name</a>, <a href="#nixpkgs_local_repository-nix_file">nix_file</a>, <a href="#nixpkgs_local_repository-nix_file_content">nix_file_content</a>, <a href="#nixpkgs_local_repository-nix_file_deps">nix_file_deps</a>)
+</pre>
 
-```bzl
-nixpkgs_local_repository(name, nix_file, nix_file_deps, nix_file_content)
-```
+Create an external repository representing the content of Nixpkgs, based on a Nix expression stored locally or provided inline. One of `nix_file` or `nix_file_content` must be provided.
 
-<table class="table table-condensed table-bordered table-params">
-  <colgroup>
-    <col class="col-param" />
-    <col class="param-description" />
-  </colgroup>
-  <thead>
-    <tr>
-      <th colspan="2">Attributes</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>name</code></td>
-      <td>
-        <p><code>Name; required</code></p>
-        <p>A unique name for this repository.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>nix_file</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>A file containing an expression for a Nix derivation.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>nix_file_deps</code></td>
-      <td>
-        <p><code>List of labels; optional</code></p>
-        <p>Dependencies of `nix_file` if any.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>nix_file_content</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>An expression for a Nix derivation.</p>
-      </td>
-    </tr>
-  </tbody>
+
+#### Attributes
+
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+<tr id="nixpkgs_local_repository-name">
+<td><code>name</code></td>
+<td>
+
+<a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
+
+<p>
+
+A unique name for this repository.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_local_repository-nix_file">
+<td><code>nix_file</code></td>
+<td>
+
+<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
+
+<p>
+
+A file containing an expression for a Nix derivation.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_local_repository-nix_file_content">
+<td><code>nix_file_content</code></td>
+<td>
+
+String; optional
+
+<p>
+
+An expression for a Nix derivation.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_local_repository-nix_file_deps">
+<td><code>nix_file_deps</code></td>
+<td>
+
+<a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a>; optional
+
+<p>
+
+Dependencies of `nix_file` if any.
+
+</p>
+</td>
+</tr>
+</tbody>
 </table>
 
-### nixpkgs_package
 
-Make the content of a Nixpkgs package available in the Bazel workspace.
-
-```bzl
-nixpkgs_package(
-    name, attribute_path, nix_file, nix_file_deps, nix_file_content,
-    repository, repositories, build_file, build_file_content, nixopts,
-    fail_not_supported,
-)
-```
-
-If `repositories` is not specified, you must provide a
-nixpkgs clone in `nix_file` or `nix_file_content`.
-
-<table class="table table-condensed table-bordered table-params">
-  <colgroup>
-    <col class="col-param" />
-    <col class="param-description" />
-  </colgroup>
-  <thead>
-    <tr>
-      <th colspan="2">Attributes</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>name</code></td>
-      <td>
-        <p><code>Name; required</code></p>
-        <p>A unique name for this target</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>attribute_path</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>Select an attribute from the top-level Nix expression being
-           evaluated. The attribute path is a sequence of attribute
-           names separated by dots.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>nix_file</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>A file containing an expression for a Nix derivation.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>nix_file_deps</code></td>
-      <td>
-        <p><code>List of labels; optional</code></p>
-        <p>Dependencies of `nix_file` if any.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>nix_file_content</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>An expression for a Nix derivation.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>repository</code></td>
-      <td>
-        <p><code>Label; optional</code></p>
-        <p>A repository label identifying which Nixpkgs to use.
-           Equivalent to `repositories = { "nixpkgs": ...}`</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>repositories</code></td>
-      <td>
-        <p><code>String-keyed label dict; optional</code></p>
-        <p>A dictionary mapping `NIX_PATH` entries to repository labels.</p>
-        <p>Setting it to
-           <pre><code>repositories = { "myrepo" : "//:myrepo" }</code></pre>
-           for example would replace all instances
-           of <code>&lt;myrepo&gt;</code> in the called nix code by the
-           path to the target <code>"//:myrepo"</code>. See the
-           <a href="https://nixos.org/nix/manual/#env-NIX_PATH">relevant
-           section in the nix manual</a> for more information.</p>
-        <p>Specify one of `path` or `repositories`.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>build_file</code></td>
-      <td>
-        <p><code>Label; optional</code></p>
-        <p>The file to use as the BUILD file for this repository.
-           Its contents are copied copied into the file
-           <code>BUILD</code> in root of the nix output folder.
-           The Label does not need to be named BUILD, but can be.
-        </p>
-        <p>For common use cases we provide filegroups that expose
-           certain files as targets:
-          <dl>
-            <dt><code>:bin</code></dt>
-            <dd>Everything in the <code>bin/</code> directory.</dd>
-            <dt><code>:lib</code></dt>
-            <dd>All <code>.so</code> and <code>.a</code> files
-              that can be found in subdirectories of
-              <code>lib/</code>.</dd>
-            <dt><code>:include</code></dt>
-            <dd>All <code>.h</code> files
-              that can be found in subdirectories of
-              <code>bin/</code>.</dd>
-          </dl>
-        </p>
-        <p>If you need different files from the nix package,
-          you can reference them like this: <pre><code>package(default_visibility = [ "//visibility:public" ])
-filegroup(
-  name = "our-docs",
-  srcs = glob(["share/doc/ourpackage/**/*"]),
-)</code></pre>
-          See the bazel documentation of
-          <a href="https://docs.bazel.build/versions/master/be/general.html#filegroup">filegroup</a>
-          and
-          <a href="https://docs.bazel.build/versions/master/be/functions.html#glob">glob</a>.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>build_file_content</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>Like <code>build_file</code>, but a string of the contents
-          instead of a file name.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>nixopts</code></td>
-      <td>
-        <p><code>String list; optional</code></p>
-        <p>
-            Extra flags to pass when calling Nix. Subject to location
-            expansion, any instance of <code>$(location LABEL)</code> will be
-            replaced by the path to the file ferenced by <code>LABEL</code>
-            relative to the workspace root.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>fail_not_supported</code></td>
-      <td>
-        <p><code>Boolean; optional; default = True</code></p>
-        <p>
-            If set to <code>True</code> (default) this rule will fail on
-            platforms which do not support Nix (e.g. Windows). If set to
-            <code>False</code> calling this rule will succeed but no output
-            will be generated.
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<a id="#nixpkgs_cc_configure"></a>
 
 ### nixpkgs_cc_configure
+
+<pre>
+nixpkgs_cc_configure(<a href="#nixpkgs_cc_configure-name">name</a>, <a href="#nixpkgs_cc_configure-attribute_path">attribute_path</a>, <a href="#nixpkgs_cc_configure-nix_file">nix_file</a>, <a href="#nixpkgs_cc_configure-nix_file_content">nix_file_content</a>, <a href="#nixpkgs_cc_configure-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_cc_configure-repositories">repositories</a>,
+                     <a href="#nixpkgs_cc_configure-repository">repository</a>, <a href="#nixpkgs_cc_configure-nixopts">nixopts</a>, <a href="#nixpkgs_cc_configure-quiet">quiet</a>, <a href="#nixpkgs_cc_configure-fail_not_supported">fail_not_supported</a>)
+</pre>
 
 Use a CC toolchain from Nixpkgs. No-op if not a nix-based platform.
 
@@ -338,353 +249,814 @@ this rule to specify explicitly which commands the toolchain should use.
 Specifically, it builds a Nix derivation that provides the CC toolchain
 tools in the `bin/` path and constructs a CC toolchain that uses those
 tools. Tools that aren't found are replaced by `${coreutils}/bin/false`.
-You can inspect the resulting `@<name>_info//:CC_TOOLCHAIN_INFO` to see
+You can inspect the resulting `@&lt;name&gt;_info//:CC_TOOLCHAIN_INFO` to see
 which tools were discovered.
 
 This rule depends on [`rules_cc`](https://github.com/bazelbuild/rules_cc).
 
 Note:
+  You need to configure `--crosstool_top=@&lt;name&gt;//:toolchain` to activate this
+  toolchain.
 
-You need to configure `--crosstool_top=@<name>//:toolchain` to activate this
-toolchain.
+Attrs:
+  attribute_path: optional, string, Obtain the toolchain from the Nix expression under this attribute path. Requires `nix_file` or `nix_file_content`.
+  nix_file: optional, Label, Obtain the toolchain from the Nix expression defined in this file. Specify only one of `nix_file` or `nix_file_content`.
+  nix_file_content: optional, string, Obtain the toolchain from the given Nix expression. Specify only one of `nix_file` or `nix_file_content`.
+  nix_file_deps: optional, list of Label, Additional files that the Nix expression depends on.
+  repositories: dict of Label to string, Provides `&lt;nixpkgs&gt;` and other repositories. Specify one of `repositories` or `repository`.
+  repository: Label, Provides `&lt;nixpkgs&gt;`. Specify one of `repositories` or `repository`.
+  nixopts: optional, list of string, Extra flags to pass when calling Nix. Subject to location expansion, any instance of `$(location LABEL)` will be replaced by the path to the file ferenced by `LABEL` relative to the workspace root.
+  quiet: bool, Whether to hide `nix-build` output.
+  fail_not_supported: bool, Whether to fail if `nix-build` is not available.
 
-Example:
+#### Parameters
 
-```bzl
-nixpkgs_cc_configure(repository = "@nixpkgs//:default.nix")
-```
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+<tr id="nixpkgs_cc_configure-name">
+<td><code>name</code></td>
+<td>
 
-<table class="table table-condensed table-bordered table-params">
-  <colgroup>
-    <col class="col-param" />
-    <col class="param-description" />
-  </colgroup>
-  <thead>
-    <tr>
-      <th colspan="2">Attributes</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>attribute_path</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>Obtain the toolchain from the Nix expression under this attribute path. Requires `nix_file` or `nix_file_content`.</p>
-      </td>
-      <td><code>nix_file</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>Obtain the toolchain from the Nix expression defined in this file. Specify only one of `nix_file` or `nix_file_content`.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>nix_file_content</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>Obtain the toolchain from the given Nix expression. Specify only one of `nix_file` or `nix_file_content`.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>nix_file_deps</code></td>
-      <td>
-        <p><code>List of labels; optional</code></p>
-        <p>Additional files that the Nix expression depends on.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>repository</code></td>
-      <td>
-        <p><code>Label; optional</code></p>
-        <p>Provides `<nixpkgs>`. Specify one of `repositories` or `repository`.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>repositories</code></td>
-      <td>
-        <p><code>String-keyed label dict; optional</code></p>
-        <p>Provides `<nixpkgs>` and other repositories. Specify one of `repositories` or `repository`.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>nixopts</code></td>
-      <td>
-        <p><code>String list; optional</code></p>
-        <p>
-            Extra flags to pass when calling Nix. Subject to location
-            expansion, any instance of <code>$(location LABEL)</code> will be
-            replaced by the path to the file ferenced by <code>LABEL</code>
-            relative to the workspace root.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>quiet</code></td>
-      <td>
-        <p><code>Bool; optional</code></p>
-        <p>Whether to hide `nix-build` output.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>fail_not_supported</code></td>
-      <td>
-        <p><code>Bool; optional</code></p>
-        <p>Whether to fail if `nix-build` is not available.</p>
-      </td>
-    </tr>
-  </tbody>
+optional.
+default is <code>"local_config_cc"</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure-attribute_path">
+<td><code>attribute_path</code></td>
+<td>
+
+optional.
+default is <code>""</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure-nix_file">
+<td><code>nix_file</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure-nix_file_content">
+<td><code>nix_file_content</code></td>
+<td>
+
+optional.
+default is <code>""</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure-nix_file_deps">
+<td><code>nix_file_deps</code></td>
+<td>
+
+optional.
+default is <code>[]</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure-repositories">
+<td><code>repositories</code></td>
+<td>
+
+optional.
+default is <code>{}</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure-repository">
+<td><code>repository</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure-nixopts">
+<td><code>nixopts</code></td>
+<td>
+
+optional.
+default is <code>[]</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure-quiet">
+<td><code>quiet</code></td>
+<td>
+
+optional.
+default is <code>False</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure-fail_not_supported">
+<td><code>fail_not_supported</code></td>
+<td>
+
+optional.
+default is <code>True</code>
+
+</td>
+</tr>
+</tbody>
 </table>
 
-### nixpkgs_cc_configure_deprecated
 
-Tells Bazel to use compilers and linkers from Nixpkgs for the CC
-toolchain. By default, Bazel autodetects a toolchain on the current
-`PATH`. Overriding this autodetection makes builds more hermetic and
-is considered a best practice.
+<a id="#nixpkgs_package"></a>
 
-Deprecated:
+### nixpkgs_package
 
-Use `nixpkgs_cc_configure` instead.
+<pre>
+nixpkgs_package(<a href="#nixpkgs_package-name">name</a>, <a href="#nixpkgs_package-attribute_path">attribute_path</a>, <a href="#nixpkgs_package-nix_file">nix_file</a>, <a href="#nixpkgs_package-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_package-nix_file_content">nix_file_content</a>, <a href="#nixpkgs_package-repository">repository</a>,
+                <a href="#nixpkgs_package-repositories">repositories</a>, <a href="#nixpkgs_package-build_file">build_file</a>, <a href="#nixpkgs_package-build_file_content">build_file_content</a>, <a href="#nixpkgs_package-nixopts">nixopts</a>, <a href="#nixpkgs_package-quiet">quiet</a>, <a href="#nixpkgs_package-fail_not_supported">fail_not_supported</a>,
+                <a href="#nixpkgs_package-kwargs">kwargs</a>)
+</pre>
 
-While this improves upon Bazel's autoconfigure toolchain by picking tools from
-a Nix derivation rather than the environment, it is still not fully hermetic as
-it is affected by the environment. In particular, system include directories
-specified in the environment can leak in and affect the cache keys of targets
-depending on the cc toolchain leading to cache misses.
+Make the content of a Nixpkgs package available in the Bazel workspace.
 
-Example:
+If `repositories` is not specified, you must provide a nixpkgs clone in `nix_file` or `nix_file_content`.
 
-```bzl
-nixpkgs_cc_configure_deprecated(repository = "@nixpkgs//:default.nix")
+
+#### Parameters
+
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+<tr id="nixpkgs_package-name">
+<td><code>name</code></td>
+<td>
+
+required.
+
+<p>
+
+A unique name for this repository.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_package-attribute_path">
+<td><code>attribute_path</code></td>
+<td>
+
+optional.
+default is <code>""</code>
+
+<p>
+
+Select an attribute from the top-level Nix expression being evaluated. The attribute path is a sequence of attribute names separated by dots.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_package-nix_file">
+<td><code>nix_file</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+A file containing an expression for a Nix derivation.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_package-nix_file_deps">
+<td><code>nix_file_deps</code></td>
+<td>
+
+optional.
+default is <code>[]</code>
+
+<p>
+
+Dependencies of `nix_file` if any.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_package-nix_file_content">
+<td><code>nix_file_content</code></td>
+<td>
+
+optional.
+default is <code>""</code>
+
+<p>
+
+An expression for a Nix derivation.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_package-repository">
+<td><code>repository</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+A repository label identifying which Nixpkgs to use. Equivalent to `repositories = { "nixpkgs": ...}`
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_package-repositories">
+<td><code>repositories</code></td>
+<td>
+
+optional.
+default is <code>{}</code>
+
+<p>
+
+A dictionary mapping `NIX_PATH` entries to repository labels.
+
+  Setting it to
+  ```
+  repositories = { "myrepo" : "//:myrepo" }
+  ```
+  for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) for more information.
+
+  Specify one of `repository` or `repositories`.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_package-build_file">
+<td><code>build_file</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+The file to use as the BUILD file for this repository.
+
+  Its contents are copied copied into the file `BUILD` in root of the nix output folder. The Label does not need to be named `BUILD`, but can be.
+
+  For common use cases we provide filegroups that expose certain files as targets:
+
+  <dl>
+    <dt><code>:bin</code></dt>
+    <dd>Everything in the <code>bin/</code> directory.</dd>
+    <dt><code>:lib</code></dt>
+    <dd>All <code>.so</code> and <code>.a</code> files that can be found in subdirectories of <code>lib/</code>.</dd>
+    <dt><code>:include</code></dt>
+    <dd>All <code>.h</code> files that can be found in subdirectories of <code>bin/</code>.</dd>
+  </dl>
+
+  If you need different files from the nix package, you can reference them like this:
+  ```
+  package(default_visibility = [ "//visibility:public" ])
+  filegroup(
+      name = "our-docs",
+      srcs = glob(["share/doc/ourpackage/**/*"]),
+  )
+  ```
+  See the bazel documentation of [`filegroup`](https://docs.bazel.build/versions/master/be/general.html#filegroup) and [`glob`](https://docs.bazel.build/versions/master/be/functions.html#glob).
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_package-build_file_content">
+<td><code>build_file_content</code></td>
+<td>
+
+optional.
+default is <code>""</code>
+
+<p>
+
+Like `build_file`, but a string of the contents instead of a file name.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_package-nixopts">
+<td><code>nixopts</code></td>
+<td>
+
+optional.
+default is <code>[]</code>
+
+<p>
+
+Extra flags to pass when calling Nix.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_package-quiet">
+<td><code>quiet</code></td>
+<td>
+
+optional.
+default is <code>False</code>
+
+<p>
+
+Whether to hide the output of the Nix command.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_package-fail_not_supported">
+<td><code>fail_not_supported</code></td>
+<td>
+
+optional.
+default is <code>True</code>
+
+<p>
+
+If set to `True` (default) this rule will fail on platforms which do not support Nix (e.g. Windows). If set to `False` calling this rule will succeed but no output will be generated.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_package-kwargs">
+<td><code>kwargs</code></td>
+<td>
+
+optional.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+
+<a id="#nixpkgs_python_configure"></a>
+
+### nixpkgs_python_configure
+
+<pre>
+nixpkgs_python_configure(<a href="#nixpkgs_python_configure-name">name</a>, <a href="#nixpkgs_python_configure-python2_attribute_path">python2_attribute_path</a>, <a href="#nixpkgs_python_configure-python2_bin_path">python2_bin_path</a>, <a href="#nixpkgs_python_configure-python3_attribute_path">python3_attribute_path</a>,
+                         <a href="#nixpkgs_python_configure-python3_bin_path">python3_bin_path</a>, <a href="#nixpkgs_python_configure-repository">repository</a>, <a href="#nixpkgs_python_configure-repositories">repositories</a>, <a href="#nixpkgs_python_configure-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_python_configure-nixopts">nixopts</a>,
+                         <a href="#nixpkgs_python_configure-fail_not_supported">fail_not_supported</a>, <a href="#nixpkgs_python_configure-quiet">quiet</a>)
+</pre>
+
+Define and register a Python toolchain provided by nixpkgs.
+
+Creates `nixpkgs_package`s for Python 2 or 3 `py_runtime` instances and a
+corresponding `py_runtime_pair` and `toolchain`. The toolchain is
+automatically registered and uses the constraint:
+
+```
+"@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix"
 ```
 
-<table class="table table-condensed table-bordered table-params">
-  <colgroup>
-    <col class="col-param" />
-    <col class="param-description" />
-  </colgroup>
-  <thead>
-    <tr>
-      <th colspan="2">Attributes</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>nix_file</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>An expression for a Nix environment derivation. The
-           environment should expose all the commands that make up
-           a CC toolchain (`cc`, `ld` etc). Exposes all commands in
-           `stdenv.cc` and `binutils` by default.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>nix_file_deps</code></td>
-      <td>
-        <p><code>List of labels; optional</code></p>
-        <p>Dependencies of `nix_file` if any.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>nix_file_content</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>An expression for a Nix environment derivation.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>repository</code></td>
-      <td>
-        <p><code>Label; optional</code></p>
-        <p>A repository label identifying which Nixpkgs to use.
-           Equivalent to `repositories = { "nixpkgs": ...}`</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>repositories</code></td>
-      <td>
-        <p><code>String-keyed label dict; optional</code></p>
-        <p>A dictionary mapping `NIX_PATH` entries to repository labels.</p>
-        <p>Setting it to
-           <pre><code>repositories = { "myrepo" : "//:myrepo" }</code></pre>
-           for example would replace all instances
-           of <code>&lt;myrepo&gt;</code> in the called nix code by the
-           path to the target <code>"//:myrepo"</code>. See the
-           <a href="https://nixos.org/nix/manual/#env-NIX_PATH">relevant
-           section in the nix manual</a> for more information.</p>
-        <p>Specify one of `path` or `repositories`.</p>
-      </td>
-    </tr>
-  </tbody>
+
+#### Parameters
+
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+<tr id="nixpkgs_python_configure-name">
+<td><code>name</code></td>
+<td>
+
+optional.
+default is <code>"nixpkgs_python_toolchain"</code>
+
+<p>
+
+The name-prefix for the created external repositories.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_python_configure-python2_attribute_path">
+<td><code>python2_attribute_path</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+The nixpkgs attribute path for python2.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_python_configure-python2_bin_path">
+<td><code>python2_bin_path</code></td>
+<td>
+
+optional.
+default is <code>"bin/python"</code>
+
+<p>
+
+The path to the interpreter within the package.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_python_configure-python3_attribute_path">
+<td><code>python3_attribute_path</code></td>
+<td>
+
+optional.
+default is <code>"python3"</code>
+
+<p>
+
+The nixpkgs attribute path for python3.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_python_configure-python3_bin_path">
+<td><code>python3_bin_path</code></td>
+<td>
+
+optional.
+default is <code>"bin/python"</code>
+
+<p>
+
+The path to the interpreter within the package.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_python_configure-repository">
+<td><code>repository</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+See [`nixpkgs_package`](#nixpkgs_package-repository).
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_python_configure-repositories">
+<td><code>repositories</code></td>
+<td>
+
+optional.
+default is <code>{}</code>
+
+<p>
+
+See [`nixpkgs_package`](#nixpkgs_package-repositories).
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_python_configure-nix_file_deps">
+<td><code>nix_file_deps</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+See [`nixpkgs_package`](#nixpkgs_package-nix_file_deps).
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_python_configure-nixopts">
+<td><code>nixopts</code></td>
+<td>
+
+optional.
+default is <code>[]</code>
+
+<p>
+
+See [`nixpkgs_package`](#nixpkgs_package-nixopts).
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_python_configure-fail_not_supported">
+<td><code>fail_not_supported</code></td>
+<td>
+
+optional.
+default is <code>True</code>
+
+<p>
+
+See [`nixpkgs_package`](#nixpkgs_package-fail_not_supported).
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_python_configure-quiet">
+<td><code>quiet</code></td>
+<td>
+
+optional.
+default is <code>False</code>
+
+<p>
+
+See [`nixpkgs_package`](#nixpkgs_package-quiet).
+
+</p>
+</td>
+</tr>
+</tbody>
 </table>
+
+
+<a id="#nixpkgs_sh_posix_configure"></a>
+
+### nixpkgs_sh_posix_configure
+
+<pre>
+nixpkgs_sh_posix_configure(<a href="#nixpkgs_sh_posix_configure-name">name</a>, <a href="#nixpkgs_sh_posix_configure-packages">packages</a>, <a href="#nixpkgs_sh_posix_configure-kwargs">kwargs</a>)
+</pre>
+
+Create a POSIX toolchain from nixpkgs.
+
+Loads the given Nix packages, scans them for standard Unix tools, and
+generates a corresponding `sh_posix_toolchain`.
+
+Make sure to call `nixpkgs_sh_posix_configure` before `sh_posix_configure`,
+if you use both. Otherwise, the local toolchain will always be chosen in
+favor of the nixpkgs one.
+
+
+#### Parameters
+
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+<tr id="nixpkgs_sh_posix_configure-name">
+<td><code>name</code></td>
+<td>
+
+optional.
+default is <code>"nixpkgs_sh_posix_config"</code>
+
+<p>
+
+Name prefix for the generated repositories.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_sh_posix_configure-packages">
+<td><code>packages</code></td>
+<td>
+
+optional.
+default is <code>["stdenv.initialPath"]</code>
+
+<p>
+
+List of Nix attribute paths to draw Unix tools from.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_sh_posix_configure-kwargs">
+<td><code>kwargs</code></td>
+<td>
+
+optional.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+
+
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Rules for importing a Go toolchain from Nixpkgs.
+
+**NOTE: The following rules must be loaded from
+`@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl` to avoid unnecessary
+dependencies on rules_go for those who don't need go toolchain.
+`io_bazel_rules_go` must be available for loading before loading of
+`@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl`.**
+
+
+<a id="#nixpkgs_go_configure"></a>
 
 ### nixpkgs_go_configure
 
-**NOTE: this rule resides in `@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl` to avoid unnecessary dependencies on rules_go for those who don't need go toolchain**
+<pre>
+nixpkgs_go_configure(<a href="#nixpkgs_go_configure-sdk_name">sdk_name</a>, <a href="#nixpkgs_go_configure-repository">repository</a>, <a href="#nixpkgs_go_configure-repositories">repositories</a>, <a href="#nixpkgs_go_configure-nix_file">nix_file</a>, <a href="#nixpkgs_go_configure-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_go_configure-nix_file_content">nix_file_content</a>,
+                     <a href="#nixpkgs_go_configure-nixopts">nixopts</a>)
+</pre>
 
-For this rule to work `rules_go` must be available for loading before loading of `@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl`.
+Use go toolchain from Nixpkgs. Will fail if not a nix-based platform.
 
-Tells bazel to use go sdk from nixpkgs. This rule **will fail** if nix is not present - you can always wrap it in rule if 
-you need to optionally provide nix support.
-
-By default rules_go configures go toolchain to be downloaded as binaries (which doesn't work on NixOS),
+By default rules_go configures the go toolchain to be downloaded as binaries (which doesn't work on NixOS),
 there is a way to tell rules_go to look into environment and find local go binary which is not hermetic.
 This command allows to setup hermetic go sdk from Nixpkgs, which should be considerate as best practice.
 
-Note that nix package must provide full go sdk at the root of the package instead of in $out/share/go
-And also provide an empty normal file named PACKAGE_ROOT at the root of package
+Note that the nix package must provide a full go sdk at the root of the package instead of in `$out/share/go`,
+and also provide an empty normal file named `PACKAGE_ROOT` at the root of package.
 
-Example:
+#### Example
 
-```bzl
-nixpkgs_go_configure(repository = "@nixpkgs//:default.nix")
-```
+  ```bzl
+  nixpkgs_go_configure(repository = "@nixpkgs//:default.nix")
+  ```
 
-Example (optional nix support when go is transitive dependency):
+  Example (optional nix support when go is a transitive dependency):
 
-```bzl
-# .bazel-lib/nixos-support.bzl
-def _has_nix(ctx):
-    return ctx.which("nix-build") != None
+  ```bzl
+  # .bazel-lib/nixos-support.bzl
+  def _has_nix(ctx):
+      return ctx.which("nix-build") != None
 
-def _gen_imports_impl(ctx):
-    ctx.file("BUILD", "")
+  def _gen_imports_impl(ctx):
+      ctx.file("BUILD", "")
 
-    imports_for_nix = """
-        load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl", "nixpkgs_go_toolchain")
+      imports_for_nix = """
+          load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl", "nixpkgs_go_toolchain")
 
-        def fix_go():
-            nixpkgs_go_toolchain(repository = "@nixpkgs")
-    """
-    imports_for_non_nix = """
-        def fix_go():
-            # if go isn't transitive you'll need to add call to go_register_toolchains here
-            pass
-    """
+          def fix_go():
+              nixpkgs_go_toolchain(repository = "@nixpkgs")
+      """
+      imports_for_non_nix = """
+          def fix_go():
+              # if go isn't transitive you'll need to add call to go_register_toolchains here
+              pass
+      """
 
-    if _has_nix(ctx):
-        ctx.file("imports.bzl", imports_for_nix)
-    else:
-        ctx.file("imports.bzl", imports_for_non_nix)
+      if _has_nix(ctx):
+          ctx.file("imports.bzl", imports_for_nix)
+      else:
+          ctx.file("imports.bzl", imports_for_non_nix)
 
-_gen_imports = repository_rule(
-    implementation = _gen_imports_impl,
-    attrs = dict(),
-)
+  _gen_imports = repository_rule(
+      implementation = _gen_imports_impl,
+      attrs = dict(),
+  )
 
-def gen_imports():
-    _gen_imports(
-        name = "nixos_support",
-    )
+  def gen_imports():
+      _gen_imports(
+          name = "nixos_support",
+      )
+
+  # WORKSPACE
+
+  // ...
+  http_archive(name = "io_tweag_rules_nixpkgs", ...)
+  // ...
+  local_repository(
+      name = "bazel_lib",
+      path = ".bazel-lib",
+  )
+  load("@bazel_lib//:nixos-support.bzl", "gen_imports")
+  gen_imports()
+  load("@nixos_support//:imports.bzl", "fix_go")
+  fix_go()
+  ```
 
 
+#### Parameters
 
-# WORKSPACE
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+<tr id="nixpkgs_go_configure-sdk_name">
+<td><code>sdk_name</code></td>
+<td>
 
-// ...
-http_archive(name = "io_tweag_rules_nixpkgs", ...)
-// ...
-local_repository(
-    name = "bazel_lib",
-    path = ".bazel-lib",
-)
-load("@bazel_lib//:nixos-support.bzl", "gen_imports")
-gen_imports()
-load("@nixos_support//:imports.bzl", "fix_go")
-fix_go()
-```
+optional.
+default is <code>"go_sdk"</code>
 
-<table class="table table-condensed table-bordered table-params">
-  <colgroup>
-    <col class="col-param" />
-    <col class="param-description" />
-  </colgroup>
-  <thead>
-    <tr>
-      <th colspan="2">Attributes</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>sdk_name</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>Go sdk name to pass in rules_go</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>nix_file</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>An expression for a Nix environment derivation. The
-           environment should expose whole go SDK (bin, src, ...) at the root of package. It also
-           must contain <code>PACKAGE_ROOT</code> file in the root of pacakge.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>nix_file_deps</code></td>
-      <td>
-        <p><code>List of labels; optional</code></p>
-        <p>Dependencies of `nix_file` if any.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>nix_file_content</code></td>
-      <td>
-        <p><code>String; optional</code></p>
-        <p>An expression for a Nix environment derivation.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>repository</code></td>
-      <td>
-        <p><code>Label; optional</code></p>
-        <p>A repository label identifying which Nixpkgs to use.
-           Equivalent to `repositories = { "nixpkgs": ...}`</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>repositories</code></td>
-      <td>
-        <p><code>String-keyed label dict; optional</code></p>
-        <p>A dictionary mapping `NIX_PATH` entries to repository labels.</p>
-        <p>Setting it to
-           <pre><code>repositories = { "myrepo" : "//:myrepo" }</code></pre>
-           for example would replace all instances
-           of <code>&lt;myrepo&gt;</code> in the called nix code by the
-           path to the target <code>"//:myrepo"</code>. See the
-           <a href="https://nixos.org/nix/manual/#env-NIX_PATH">relevant
-           section in the nix manual</a> for more information.</p>
-        <p>Specify one of `path` or `repositories`.</p>
-      </td>
-    </tr>
-  </tbody>
+<p>
+
+Go sdk name to pass to rules_go
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_go_configure-repository">
+<td><code>repository</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+A repository label identifying which Nixpkgs to use. Equivalent to `repositories = { "nixpkgs": ...}`.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_go_configure-repositories">
+<td><code>repositories</code></td>
+<td>
+
+optional.
+default is <code>{}</code>
+
+<p>
+
+A dictionary mapping `NIX_PATH` entries to repository labels.
+
+  Setting it to
+  ```
+  repositories = { "myrepo" : "//:myrepo" }
+  ```
+  for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) in the nix manual for more information.
+
+  Specify one of `path` or `repositories`.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_go_configure-nix_file">
+<td><code>nix_file</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+An expression for a Nix environment derivation. The environment should expose the whole go SDK (`bin`, `src`, ...) at the root of package. It also must contain a `PACKAGE_ROOT` file in the root of pacakge.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_go_configure-nix_file_deps">
+<td><code>nix_file_deps</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+Dependencies of `nix_file` if any.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_go_configure-nix_file_content">
+<td><code>nix_file_content</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+An expression for a Nix environment derivation.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_go_configure-nixopts">
+<td><code>nixopts</code></td>
+<td>
+
+optional.
+default is <code>[]</code>
+
+</td>
+</tr>
+</tbody>
 </table>
 
-## Migration
 
-### `path` Attribute
 
-`path` was an attribute from the early days of `rules_nixpkgs`, and
-its ability to reference arbitrary paths a danger to build hermeticity.
-
-Replace it with either `nixpkgs_git_repository` if you need
-a specific version of `nixpkgs`. If you absolutely *must* depend on a
-local folder, use bazel’s
-[`local_repository` workspace rule](https://docs.bazel.build/versions/master/be/workspace.html#local_repository).
-Both approaches work well with the `repositories` attribute of `nixpkgs_package`.
-
-```bzl
-local_repository(
-  name = "local-nixpkgs",
-  path = "/path/to/nixpkgs",
-)
-
-nixpkgs_package(
-  name = "somepackage",
-  repositories = {
-    "nixpkgs": "@local-nixpkgs//:default.nix",
-  },
-  …
-)
-```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "io_tweag_rules_nixpkgs")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 load("//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
 
 rules_nixpkgs_dependencies()
@@ -13,6 +15,22 @@ load(
     "nixpkgs_python_configure",
     "nixpkgs_sh_posix_configure",
 )
+
+# For documentation
+
+http_archive(
+    name = "io_bazel_stardoc",
+    sha256 = "6d07d18c15abb0f6d393adbd6075cd661a2219faab56a9517741f0fc755f6f3c",
+    strip_prefix = "stardoc-0.4.0",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/archive/0.4.0.tar.gz",
+        "https://github.com/bazelbuild/stardoc/archive/0.4.0.tar.gz",
+    ],
+)
+
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
+stardoc_repositories()
 
 # For tests
 
@@ -202,8 +220,6 @@ nixpkgs_package(
     ],
     repository = "@remote_nixpkgs",
 )
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_sh",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -226,10 +226,11 @@ sh_posix_configure()
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "b27e55d2dcc9e6020e17614ae6e0374818a3e3ce6f2024036e688ada24110444",
+    sha256 = "fa7c8682999a5516a8844c1963365b478e13d4f558041a840fc1b2c41567955d",
+    strip_prefix = "rules_go-c3e725364a20d2f3549a297c14194cb133e78753",
     urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.21.0/rules_go-v0.21.0.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.21.0/rules_go-v0.21.0.tar.gz",
+        # XXX: Update once upstream PR is merged https://github.com/bazelbuild/rules_go/pull/2620
+        "https://github.com/bazelbuild/rules_go/archive/c3e725364a20d2f3549a297c14194cb133e78753.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -242,11 +242,11 @@ sh_posix_configure()
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "fa7c8682999a5516a8844c1963365b478e13d4f558041a840fc1b2c41567955d",
-    strip_prefix = "rules_go-c3e725364a20d2f3549a297c14194cb133e78753",
+    sha256 = "6d7285b47655379752da1956b053d924e4268feaf8bb6c460940a58fd132bdf0",
+    strip_prefix = "rules_go-88800debc0aa167faa63ae3ceaf8203568c5bcc8",
     urls = [
-        # XXX: Update once upstream PR is merged https://github.com/bazelbuild/rules_go/pull/2620
-        "https://github.com/bazelbuild/rules_go/archive/c3e725364a20d2f3549a297c14194cb133e78753.tar.gz",
+        # XXX: Update once upstream PR is merged https://github.com/bazelbuild/rules_go/pull/2621
+        "https://github.com/bazelbuild/rules_go/archive/88800debc0aa167faa63ae3ceaf8203568c5bcc8.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -241,11 +241,12 @@ sh_posix_configure()
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "6d7285b47655379752da1956b053d924e4268feaf8bb6c460940a58fd132bdf0",
-    strip_prefix = "rules_go-88800debc0aa167faa63ae3ceaf8203568c5bcc8",
+    sha256 = "c024f8272a6042b5a438fbc56a673ec1c839241980aa695ab3fcf6ecc40e69d8",
+    strip_prefix = "rules_go-2bada599e10349d42e369cab1ec4f4679f148598",
     urls = [
-        # XXX: Update once upstream PR is merged https://github.com/bazelbuild/rules_go/pull/2621
-        "https://github.com/bazelbuild/rules_go/archive/88800debc0aa167faa63ae3ceaf8203568c5bcc8.tar.gz",
+        # XXX: Update once a release is available that includes
+        # https://github.com/bazelbuild/rules_go/pull/2621
+        "https://github.com/bazelbuild/rules_go/archive/2bada599e10349d42e369cab1ec4f4679f148598.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,6 @@
 workspace(name = "io_tweag_rules_nixpkgs")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 load("//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
 
 rules_nixpkgs_dependencies()

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -1,0 +1,26 @@
+load("stardoc.bzl", "stardoc")
+
+stardoc(
+    name = "nixpkgs",
+    out = "nixpkgs.md",
+    input = "//nixpkgs:nixpkgs.bzl",
+    deps = ["//nixpkgs"],
+    symbol_names = [
+        "nixpkgs_git_repository",
+        "nixpkgs_local_repository",
+        "nixpkgs_package",
+        "nixpkgs_cc_configure",
+        "nixpkgs_python_configure",
+        "nixpkgs_sh_posix_configure",
+    ],
+)
+
+stardoc(
+    name = "go",
+    out = "toolchains/go.md",
+    input = "//nixpkgs:toolchains/go.bzl",
+    deps = ["//nixpkgs:toolchains_go"],
+    symbol_names = [
+        "nixpkgs_go_configure",
+    ],
+)

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -24,3 +24,46 @@ stardoc(
         "nixpkgs_go_configure",
     ],
 )
+
+genrule(
+    name = "readme",
+    srcs = [
+        "README.md.tpl",
+        "nixpkgs.md",
+        "toolchains/go.md",
+    ],
+    outs = ["README.md"],
+    toolchains = ["@rules_sh//sh/posix:make_variables"],
+    cmd = """\
+$(POSIX_AWK) \\
+  <$(execpath README.md.tpl) \\
+  >$(OUTS) \\
+  '{
+      if (/%nixpkgs%/) {
+          RS="\\0";
+          getline content <"$(execpath nixpkgs.md)";
+          print content
+      } else if (/%toolchains_go%/) {
+          RS="\\0";
+          getline content <"$(execpath toolchains/go.md)";
+          print content
+      } else {
+          print
+      }
+  }'
+""",
+)
+
+sh_test(
+    name = "check-readme",
+    srcs = ["check-readme.sh"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+    data = ["//:README.md", "README.md"],
+)
+
+sh_binary(
+    name = "update-readme",
+    srcs = ["update-readme.sh"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+    data = ["README.md"],
+)

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -4,7 +4,6 @@ stardoc(
     name = "nixpkgs",
     out = "nixpkgs.md",
     input = "//nixpkgs:nixpkgs.bzl",
-    deps = ["//nixpkgs"],
     symbol_names = [
         "nixpkgs_git_repository",
         "nixpkgs_local_repository",
@@ -13,16 +12,17 @@ stardoc(
         "nixpkgs_python_configure",
         "nixpkgs_sh_posix_configure",
     ],
+    deps = ["//nixpkgs"],
 )
 
 stardoc(
     name = "go",
     out = "toolchains/go.md",
     input = "//nixpkgs:toolchains/go.bzl",
-    deps = ["//nixpkgs:toolchains_go"],
     symbol_names = [
         "nixpkgs_go_configure",
     ],
+    deps = ["//nixpkgs:toolchains_go"],
 )
 
 genrule(
@@ -33,9 +33,7 @@ genrule(
         "toolchains/go.md",
     ],
     outs = ["README.md"],
-    toolchains = ["@rules_sh//sh/posix:make_variables"],
-    cmd = """\
-$(POSIX_AWK) \\
+    cmd = """$(POSIX_AWK) \\
   <$(execpath README.md.tpl) \\
   >$(OUTS) \\
   '{
@@ -52,18 +50,22 @@ $(POSIX_AWK) \\
       }
   }'
 """,
+    toolchains = ["@rules_sh//sh/posix:make_variables"],
 )
 
 sh_test(
     name = "check-readme",
     srcs = ["check-readme.sh"],
+    data = [
+        "README.md",
+        "//:README.md",
+    ],
     deps = ["@bazel_tools//tools/bash/runfiles"],
-    data = ["//:README.md", "README.md"],
 )
 
 sh_binary(
     name = "update-readme",
     srcs = ["update-readme.sh"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
     data = ["README.md"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -38,11 +38,11 @@ genrule(
   <$(execpath README.md.tpl) \\
   >$(OUTS) \\
   '{
-      if (/%nixpkgs%/) {
+      if (/{{nixpkgs}}/) {
           RS="\\0";
           getline content <"$(execpath nixpkgs.md)";
           print content
-      } else if (/%toolchains_go%/) {
+      } else if (/{{toolchains_go}}/) {
           RS="\\0";
           getline content <"$(execpath toolchains/go.md)";
           print content

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -9,6 +9,7 @@ stardoc(
         "nixpkgs_local_repository",
         "nixpkgs_package",
         "nixpkgs_cc_configure",
+        "nixpkgs_cc_configure_deprecated",
         "nixpkgs_python_configure",
         "nixpkgs_sh_posix_configure",
     ],

--- a/docs/README.md.tpl
+++ b/docs/README.md.tpl
@@ -51,6 +51,15 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository", "
 load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl", "nixpkgs_go_toolchain") # optional
 ```
 
+If you use `rules_nixpkgs` to configure a toolchain then you will also need to
+configure the build platform to include the
+`@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix` constraint. For
+example by adding the following to `.bazelrc`:
+
+```
+build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
+```
+
 ## Example
 
 ```bzl

--- a/docs/README.md.tpl
+++ b/docs/README.md.tpl
@@ -77,9 +77,9 @@ nixpkgs_package(
 
 ## Rules
 
-%nixpkgs%
+{{nixpkgs}}
 
-%toolchains_go%
+{{toolchains_go}}
 
 ## Migration
 

--- a/docs/README.md.tpl
+++ b/docs/README.md.tpl
@@ -1,0 +1,101 @@
+<!-- Edit docs/README.md.tpl and run `bazel run //docs:update-readme` to change the project README. -->
+
+# Nixpkgs rules for Bazel
+
+[![Build status](https://badge.buildkite.com/79bd0a8aa1e47a92e0254ca3afe5f439776e6d389cfbde9d8c.svg?branch=master)](https://buildkite.com/tweag-1/rules-nixpkgs)
+
+Use [Nix][nix] and the [Nixpkgs][nixpkgs] package set to import
+external dependencies (like system packages) into [Bazel][bazel]
+hermetically. If the version of any dependency changes, Bazel will
+correctly rebuild targets, and only those targets that use the
+external dependencies that changed.
+
+Links:
+* [Nix + Bazel = fully reproducible, incremental
+  builds][blog-bazel-nix] (blog post)
+* [Nix + Bazel][youtube-bazel-nix] (lightning talk)
+
+[nix]: https://nixos.org/nix
+[nixpkgs]: https://github.com/NixOS/nixpkgs
+[bazel]: https://bazel.build
+[blog-bazel-nix]: https://www.tweag.io/posts/2018-03-15-bazel-nix.html
+[youtube-bazel-nix]: https://www.youtube.com/watch?v=hDdDUrty1Gw
+
+## Rules
+
+* [nixpkgs_git_repository](#nixpkgs_git_repository)
+* [nixpkgs_local_repository](#nixpkgs_local_repository)
+* [nixpkgs_package](#nixpkgs_package)
+* [nixpkgs_cc_configure](#nixpkgs_cc_configure)
+* [nixpkgs_cc_configure_deprecated](#nixpkgs_cc_configure_deprecated)
+* [nixpkgs_python_configure](#nixpkgs_python_configure)
+* [nixpkgs_sh_posix_configure](#nixpkgs_sh_posix_configure)
+* [nixpkgs_go_configure](#nixpkgs_go_configure)
+
+## Setup
+
+Add the following to your `WORKSPACE` file, and select a `$COMMIT` accordingly.
+
+```bzl
+http_archive(
+    name = "io_tweag_rules_nixpkgs",
+    strip_prefix = "rules_nixpkgs-$COMMIT",
+    urls = ["https://github.com/tweag/rules_nixpkgs/archive/$COMMIT.tar.gz"],
+)
+
+load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
+rules_nixpkgs_dependencies()
+
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository", "nixpkgs_package", "nixpkgs_cc_toolchain")
+
+load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl", "nixpkgs_go_toolchain") # optional
+```
+
+## Example
+
+```bzl
+nixpkgs_git_repository(
+    name = "nixpkgs",
+    revision = "17.09", # Any tag or commit hash
+    sha256 = "" # optional sha to verify package integrity!
+)
+
+nixpkgs_package(
+    name = "hello",
+    repositories = { "nixpkgs": "@nixpkgs//:default.nix" }
+)
+```
+
+## Rules
+
+%nixpkgs%
+
+%toolchains_go%
+
+## Migration
+
+### `path` Attribute
+
+`path` was an attribute from the early days of `rules_nixpkgs`, and
+its ability to reference arbitrary paths a danger to build hermeticity.
+
+Replace it with either `nixpkgs_git_repository` if you need
+a specific version of `nixpkgs`. If you absolutely *must* depend on a
+local folder, use bazel’s
+[`local_repository` workspace rule](https://docs.bazel.build/versions/master/be/workspace.html#local_repository).
+Both approaches work well with the `repositories` attribute of `nixpkgs_package`.
+
+```bzl
+local_repository(
+  name = "local-nixpkgs",
+  path = "/path/to/nixpkgs",
+)
+
+nixpkgs_package(
+  name = "somepackage",
+  repositories = {
+    "nixpkgs": "@local-nixpkgs//:default.nix",
+  },
+  …
+)
+```

--- a/docs/check-readme.sh
+++ b/docs/check-readme.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+set -euo pipefail
+
+old="$(rlocation io_tweag_rules_nixpkgs/README.md)"
+new="$(rlocation io_tweag_rules_nixpkgs/docs/README.md)"
+
+if ! cmp -s "$old" "$new"; then
+  cat >&2 <<EOF
+The project README is not up-to-date.
+Please update it using the following command.
+
+  bazel run //docs:update-readme
+
+EOF
+  exit 1
+fi

--- a/docs/stardoc.bzl
+++ b/docs/stardoc.bzl
@@ -1,0 +1,23 @@
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", _stardoc = "stardoc")
+
+def stardoc(
+        name,
+        out,
+        input,
+        aspect_template = "@io_tweag_rules_nixpkgs//docs:templates/aspect.vm",
+        func_template = "@io_tweag_rules_nixpkgs//docs:templates/func.vm",
+        header_template = "@io_tweag_rules_nixpkgs//docs:templates/header.vm",
+        provider_template = "@io_tweag_rules_nixpkgs//docs:templates/provider.vm",
+        rule_template = "@io_tweag_rules_nixpkgs//docs:templates/rule.vm",
+        **kwargs):
+    _stardoc(
+        name = name,
+        out = out,
+        input = input,
+        aspect_template = aspect_template,
+        func_template = func_template,
+        header_template = header_template,
+        provider_template = provider_template,
+        rule_template = rule_template,
+        **kwargs
+    )

--- a/docs/templates/aspect.vm
+++ b/docs/templates/aspect.vm
@@ -1,0 +1,60 @@
+<a id="#${aspectName}"></a>
+
+#[[###]]# ${aspectName}
+
+<pre>
+${util.aspectSummary($aspectName, $aspectInfo)}
+</pre>
+
+$aspectInfo.getDocString()
+
+#[[####]]# Aspect Attributes
+
+#if (!$aspectInfo.getAspectAttributeList().isEmpty())
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+#foreach ($aspectAttribute in $aspectInfo.getAspectAttributeList())
+<tr id="${aspectName}-${aspectAttribute}">
+<td><code>${aspectAttribute}</code></td>
+<td>
+String; required.
+</td>
+</tr>
+#end
+</tbody>
+</table>
+#end
+
+#[[####]]# Attributes
+
+#if (!$aspectInfo.getAttributeList().isEmpty())
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+#foreach ($attribute in $aspectInfo.getAttributeList())
+<tr id="${aspectName}-${attribute.name}">
+<td><code>${attribute.name}</code></td>
+<td>
+
+${util.attributeTypeString($attribute)}; ${util.mandatoryString($attribute)}
+
+#if (!$attribute.docString.isEmpty())
+<p>
+
+${attribute.docString.trim()}
+
+</p>
+#end
+</td>
+</tr>
+#end
+</tbody>
+</table>
+#end

--- a/docs/templates/func.vm
+++ b/docs/templates/func.vm
@@ -1,0 +1,42 @@
+<a id="#${funcInfo.functionName}"></a>
+
+#[[###]]# ${funcInfo.functionName}
+
+<pre>
+${util.funcSummary($funcInfo)}
+</pre>
+
+${util.htmlEscape($funcInfo.docString)}
+
+#if (!$funcInfo.getParameterList().isEmpty())
+#[[####]]# Parameters
+
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+#foreach ($param in $funcInfo.getParameterList())
+<tr id="${funcInfo.functionName}-${param.name}">
+<td><code>${param.name}</code></td>
+<td>
+
+${util.mandatoryString($param)}.
+#if(!$param.getDefaultValue().isEmpty())
+default is <code>$param.getDefaultValue()</code>
+#end
+
+#if (!$param.docString.isEmpty())
+<p>
+
+${param.docString.trim()}
+
+</p>
+#end
+</td>
+</tr>
+#end
+</tbody>
+</table>
+#end

--- a/docs/templates/func.vm
+++ b/docs/templates/func.vm
@@ -6,7 +6,7 @@
 ${util.funcSummary($funcInfo)}
 </pre>
 
-${util.htmlEscape($funcInfo.docString)}
+${funcInfo.docString}
 
 #if (!$funcInfo.getParameterList().isEmpty())
 #[[####]]# Parameters

--- a/docs/templates/header.vm
+++ b/docs/templates/header.vm
@@ -1,0 +1,3 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+${moduleDocstring}

--- a/docs/templates/provider.vm
+++ b/docs/templates/provider.vm
@@ -1,0 +1,34 @@
+<a id="#${providerName}"></a>
+
+#[[###]]# ${providerName}
+
+<pre>
+${util.providerSummary($providerName, $providerInfo)}
+</pre>
+
+${util.htmlEscape($providerInfo.docString)}
+
+#if (!$providerInfo.fieldInfoList.isEmpty())
+#[[####]]# Fields
+
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+#foreach ($field in $providerInfo.fieldInfoList)
+<tr id="${providerName}-${field.name}">
+<td><code>${field.name}</code></td>
+<td>
+<p>
+
+${field.docString}
+
+</p>
+</td>
+</tr>
+#end
+</tbody>
+</table>
+#end

--- a/docs/templates/provider.vm
+++ b/docs/templates/provider.vm
@@ -6,7 +6,7 @@
 ${util.providerSummary($providerName, $providerInfo)}
 </pre>
 
-${util.htmlEscape($providerInfo.docString)}
+${providerInfo.docString}
 
 #if (!$providerInfo.fieldInfoList.isEmpty())
 #[[####]]# Fields

--- a/docs/templates/rule.vm
+++ b/docs/templates/rule.vm
@@ -1,0 +1,46 @@
+<a id="#${ruleName}"></a>
+
+#[[###]]# ${ruleName}
+
+<pre>
+${util.ruleSummary($ruleName, $ruleInfo)}
+</pre>
+
+${util.htmlEscape($ruleInfo.docString)}
+
+#[[####]]# Attributes
+
+#if (!$ruleInfo.getAttributeList().isEmpty())
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+#foreach ($attribute in $ruleInfo.getAttributeList())
+<tr id="${ruleName}-${attribute.name}">
+<td><code>${attribute.name}</code></td>
+<td>
+
+${util.attributeTypeString($attribute)}; ${util.mandatoryString($attribute)}
+
+#if (!$attribute.docString.isEmpty())
+<p>
+
+${attribute.docString.trim()}
+
+</p>
+#end
+#if (!$attribute.getProviderNameGroupList().isEmpty())
+<p>
+
+The dependencies of this attribute must provide: ${util.attributeProviders($attribute)}
+
+</p>
+#end
+</td>
+</tr>
+#end
+</tbody>
+</table>
+#end

--- a/docs/templates/rule.vm
+++ b/docs/templates/rule.vm
@@ -6,7 +6,7 @@
 ${util.ruleSummary($ruleName, $ruleInfo)}
 </pre>
 
-${util.htmlEscape($ruleInfo.docString)}
+${ruleInfo.docString}
 
 #[[####]]# Attributes
 

--- a/docs/update-readme.sh
+++ b/docs/update-readme.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+set -euo pipefail
+
+new="$(rlocation io_tweag_rules_nixpkgs/docs/README.md)"
+
+# this variable is set by `bazel run`
+if [ -z "$BUILD_WORKSPACE_DIRECTORY" ]; then
+    echo "This script must be executed using bazel run." >&2
+    exit 1
+fi
+
+cp "$new" "$BUILD_WORKSPACE_DIRECTORY/README.md"

--- a/nixpkgs.json
+++ b/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "owner": "NixOS",
-  "repo": "nixpkgs-channels",
-  "branch": "nixos-unstable",
-  "rev": "1d8018068278a717771e9ec4054dff1ebd3252b0",
-  "sha256": "1vi3wbvlvpd4200swd3594vps1fsnd7775mgzm3nnfs1imzkg00i"
+  "repo": "nixpkgs",
+  "branch": "nixpkgs-unstable",
+  "rev": "752b6a95db93f03d6901304f760bd452b4b7db41",
+  "sha256": "16vxh0bj9qx9x4pncax3bl8z1awy20dcw5xqk01znay8qyml73w5"
 }

--- a/nixpkgs/BUILD.bazel
+++ b/nixpkgs/BUILD.bazel
@@ -45,5 +45,19 @@ bzl_library(
         "@bazel_skylib//lib:new_sets",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:sets",
+        "@bazel_skylib//lib:versions",
+    ],
+)
+
+bzl_library(
+    name = "toolchains_go",
+    srcs = [
+        "toolchains/go.bzl",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bazel_tools",
+        ":nixpkgs",
+        "@io_bazel_rules_go//go:go_lib",
     ],
 )

--- a/nixpkgs/BUILD.bazel
+++ b/nixpkgs/BUILD.bazel
@@ -58,6 +58,6 @@ bzl_library(
     deps = [
         ":bazel_tools",
         ":nixpkgs",
-        "@io_bazel_rules_go//go:go_lib",
+        "@io_bazel_rules_go//go:deps",
     ],
 )

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -640,11 +640,11 @@ def nixpkgs_cc_configure(
 
     This rule depends on [`rules_cc`](https://github.com/bazelbuild/rules_cc).
 
-    Note:
-      You need to configure `--crosstool_top=@<name>//:toolchain` to activate this
-      toolchain.
+    **Note:**
+    You need to configure `--crosstool_top=@<name>//:toolchain` to activate
+    this toolchain.
 
-    Attrs:
+    Args:
       attribute_path: optional, string, Obtain the toolchain from the Nix expression under this attribute path. Requires `nix_file` or `nix_file_content`.
       nix_file: optional, Label, Obtain the toolchain from the Nix expression defined in this file. Specify only one of `nix_file` or `nix_file_content`.
       nix_file_content: optional, string, Obtain the toolchain from the given Nix expression. Specify only one of `nix_file` or `nix_file_content`.
@@ -815,16 +815,6 @@ def nixpkgs_cc_configure_deprecated(
     the environment (e.g. `gcc`). Overriding this autodetection makes builds
     more hermetic and is considered a best practice.
 
-    Deprecated:
-      Use `nixpkgs_cc_configure` instead.
-
-      While this improves upon Bazel's autoconfigure toolchain by picking tools
-      from a Nix derivation rather than the environment, it is still not fully
-      hermetic as it is affected by the environment. In particular, system
-      include directories specified in the environment can leak in and affect
-      the cache keys of targets depending on the cc toolchain leading to cache
-      misses.
-
     #### Example
 
       ```bzl
@@ -850,6 +840,16 @@ def nixpkgs_cc_configure_deprecated(
       nix_file_deps: Dependencies of `nix_file` if any.
       nix_file_content: An expression for a Nix environment derivation.
       nixopts: Options to forward to the nix command.
+
+    Deprecated:
+      Use `nixpkgs_cc_configure` instead.
+
+      While this improves upon Bazel's autoconfigure toolchain by picking tools
+      from a Nix derivation rather than the environment, it is still not fully
+      hermetic as it is affected by the environment. In particular, system
+      include directories specified in the environment can leak in and affect
+      the cache keys of targets depending on the cc toolchain leading to cache
+      misses.
     """
     if not nix_file and not nix_file_content:
         nix_file_content = """

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -31,10 +31,19 @@ def _nixpkgs_git_repository_impl(repository_ctx):
 nixpkgs_git_repository = repository_rule(
     implementation = _nixpkgs_git_repository_impl,
     attrs = {
-        "revision": attr.string(mandatory = True),
-        "remote": attr.string(default = "https://github.com/NixOS/nixpkgs"),
-        "sha256": attr.string(),
+        "revision": attr.string(
+            mandatory = True,
+            doc = "Git commit hash or tag identifying the version of Nixpkgs to use.",
+        ),
+        "remote": attr.string(
+            default = "https://github.com/NixOS/nixpkgs",
+            doc = "The URI of the remote Git repository. This must be a HTTP URL. There is currently no support for authentication. Defaults to [upstream nixpkgs](https://github.com/NixOS/nixpkgs).",
+        ),
+        "sha256": attr.string(doc = "The SHA256 used to verify the integrity of the repository."),
     },
+    doc = """\
+Name a specific revision of Nixpkgs on GitHub or a local checkout.
+""",
 )
 
 def _nixpkgs_local_repository_impl(repository_ctx):
@@ -73,10 +82,20 @@ def _nixpkgs_local_repository_impl(repository_ctx):
 nixpkgs_local_repository = repository_rule(
     implementation = _nixpkgs_local_repository_impl,
     attrs = {
-        "nix_file": attr.label(allow_single_file = [".nix"]),
-        "nix_file_deps": attr.label_list(),
-        "nix_file_content": attr.string(),
+        "nix_file": attr.label(
+            allow_single_file = [".nix"],
+            doc = "A file containing an expression for a Nix derivation.",
+        ),
+        "nix_file_deps": attr.label_list(
+            doc = "Dependencies of `nix_file` if any.",
+        ),
+        "nix_file_content": attr.string(
+            doc = "An expression for a Nix derivation.",
+        ),
     },
+    doc = """\
+Create an external repository representing the content of Nixpkgs, based on a Nix expression stored locally or provided inline. One of `nix_file` or `nix_file_content` must be provided.
+""",
 )
 
 def _is_supported_platform(repository_ctx):
@@ -248,7 +267,83 @@ _nixpkgs_package = repository_rule(
     },
 )
 
-def nixpkgs_package(*args, **kwargs):
+def nixpkgs_package(
+        name,
+        attribute_path = "",
+        nix_file = None,
+        nix_file_deps = [],
+        nix_file_content = "",
+        repository = None,
+        repositories = {},
+        build_file = None,
+        build_file_content = "",
+        nixopts = [],
+        quiet = False,
+        fail_not_supported = True,
+        **kwargs):
+    """Make the content of a Nixpkgs package available in the Bazel workspace.
+
+    If `repositories` is not specified, you must provide a nixpkgs clone in `nix_file` or `nix_file_content`.
+
+    Args:
+      name: A unique name for this repository.
+      attribute_path: Select an attribute from the top-level Nix expression being evaluated. The attribute path is a sequence of attribute names separated by dots.
+      nix_file: A file containing an expression for a Nix derivation.
+      nix_file_deps: Dependencies of `nix_file` if any.
+      nix_file_content: An expression for a Nix derivation.
+      repository: A repository label identifying which Nixpkgs to use. Equivalent to `repositories = { "nixpkgs": ...}`
+      repositories: A dictionary mapping `NIX_PATH` entries to repository labels.
+
+        Setting it to
+        ```
+        repositories = { "myrepo" : "//:myrepo" }
+        ```
+        for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) for more information.
+
+        Specify one of `repository` or `repositories`.
+      build_file: The file to use as the BUILD file for this repository.
+
+        Its contents are copied copied into the file `BUILD` in root of the nix output folder. The Label does not need to be named `BUILD`, but can be.
+
+        For common use cases we provide filegroups that expose certain files as targets:
+
+        <dl>
+          <dt><code>:bin</code></dt>
+          <dd>Everything in the <code>bin/</code> directory.</dd>
+          <dt><code>:lib</code></dt>
+          <dd>All <code>.so</code> and <code>.a</code> files that can be found in subdirectories of <code>lib/</code>.</dd>
+          <dt><code>:include</code></dt>
+          <dd>All <code>.h</code> files that can be found in subdirectories of <code>bin/</code>.</dd>
+        </dl>
+
+        If you need different files from the nix package, you can reference them like this:
+        ```
+        package(default_visibility = [ "//visibility:public" ])
+        filegroup(
+            name = "our-docs",
+            srcs = glob(["share/doc/ourpackage/**/*"]),
+        )
+        ```
+        See the bazel documentation of [`filegroup`](https://docs.bazel.build/versions/master/be/general.html#filegroup) and [`glob`](https://docs.bazel.build/versions/master/be/functions.html#glob).
+      build_file_content: Like `build_file`, but a string of the contents instead of a file name.
+      nixopts: Extra flags to pass when calling Nix.
+      quiet: Whether to hide the output of the Nix command.
+      fail_not_supported: If set to `True` (default) this rule will fail on platforms which do not support Nix (e.g. Windows). If set to `False` calling this rule will succeed but no output will be generated.
+    """
+    kwargs.update(
+        name = name,
+        attribute_path = attribute_path,
+        nix_file = nix_file,
+        nix_file_deps = nix_file_deps,
+        nix_file_content = nix_file_content,
+        repository = repository,
+        repositories = repositories,
+        build_file = build_file,
+        build_file_content = build_file_content,
+        nixopts = nixopts,
+        quiet = quiet,
+        fail_not_supported = fail_not_supported,
+    )
     # Because of https://github.com/bazelbuild/bazel/issues/7989 we can't
     # directly pass a dict from strings to labels to the rule (which we'd like
     # for the `repositories` arguments), but we can pass a dict from labels to
@@ -256,14 +351,9 @@ def nixpkgs_package(*args, **kwargs):
     # distinct).
     if "repositories" in kwargs:
         inversed_repositories = {value: key for (key, value) in kwargs["repositories"].items()}
-        kwargs.pop("repositories")
-        _nixpkgs_package(
-            repositories = inversed_repositories,
-            *args,
-            **kwargs
-        )
-    else:
-        _nixpkgs_package(*args, **kwargs)
+        kwargs["repositories"] = inversed_repositories
+
+    _nixpkgs_package(**kwargs)
 
 def _parse_cc_toolchain_info(content, filename):
     """Parses the `CC_TOOLCHAIN_INFO` file generated by Nix.
@@ -719,6 +809,11 @@ def nixpkgs_cc_configure_deprecated(
         nixopts = []):
     """Use a CC toolchain from Nixpkgs. No-op if not a nix-based platform.
 
+    Tells Bazel to use compilers and linkers from Nixpkgs for the CC toolchain.
+    By default, Bazel auto-configures a CC toolchain from commands available in
+    the environment (e.g. `gcc`). Overriding this autodetection makes builds
+    more hermetic and is considered a best practice.
+
     Deprecated:
       Use `nixpkgs_cc_configure` instead.
 
@@ -729,10 +824,31 @@ def nixpkgs_cc_configure_deprecated(
       the cache keys of targets depending on the cc toolchain leading to cache
       misses.
 
-    By default, Bazel auto-configures a CC toolchain from commands (e.g.
-    `gcc`) available in the environment. To make builds more hermetic, use
-    this rule to specific explicitly which commands the toolchain should
-    use.
+    #### Example
+
+      ```bzl
+      nixpkgs_cc_configure(repository = "@nixpkgs//:default.nix")
+      ```
+
+    Args:
+      repository: A repository label identifying which Nixpkgs to use.
+        Equivalent to `repositories = { "nixpkgs": ...}`.
+      repositories: A dictionary mapping `NIX_PATH` entries to repository labels.
+
+        Setting it to
+        ```
+        repositories = { "myrepo" : "//:myrepo" }
+        ```
+        for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) for more information.
+
+        Specify one of `repository` or `repositories`.
+      nix_file: An expression for a Nix environment derivation.
+        The environment should expose all the commands that make up a CC
+        toolchain (`cc`, `ld` etc). Exposes all commands in `stdenv.cc` and
+        `binutils` by default.
+      nix_file_deps: Dependencies of `nix_file` if any.
+      nix_file_content: An expression for a Nix environment derivation.
+      nixopts: Options to forward to the nix command.
     """
     if not nix_file and not nix_file_content:
         nix_file_content = """
@@ -838,15 +954,23 @@ def nixpkgs_python_configure(
     Creates `nixpkgs_package`s for Python 2 or 3 `py_runtime` instances and a
     corresponding `py_runtime_pair` and `toolchain`. The toolchain is
     automatically registered and uses the constraint:
-      "@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix"
 
-    Attrs:
+    ```
+    "@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix"
+    ```
+
+    Args:
       name: The name-prefix for the created external repositories.
       python2_attribute_path: The nixpkgs attribute path for python2.
       python2_bin_path: The path to the interpreter within the package.
       python3_attribute_path: The nixpkgs attribute path for python3.
       python3_bin_path: The path to the interpreter within the package.
-      ...: See `nixpkgs_package` for the remaining attributes.
+      repository: See [`nixpkgs_package`](#nixpkgs_package-repository).
+      repositories: See [`nixpkgs_package`](#nixpkgs_package-repositories).
+      nix_file_deps: See [`nixpkgs_package`](#nixpkgs_package-nix_file_deps).
+      nixopts: See [`nixpkgs_package`](#nixpkgs_package-nixopts).
+      fail_not_supported: See [`nixpkgs_package`](#nixpkgs_package-fail_not_supported).
+      quiet: See [`nixpkgs_package`](#nixpkgs_package-quiet).
     """
     python2_specified = python2_attribute_path and python2_bin_path
     python3_specified = python3_attribute_path and python3_bin_path

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -344,6 +344,7 @@ def nixpkgs_package(
         quiet = quiet,
         fail_not_supported = fail_not_supported,
     )
+
     # Because of https://github.com/bazelbuild/bazel/issues/7989 we can't
     # directly pass a dict from strings to labels to the rule (which we'd like
     # for the `repositories` arguments), but we can pass a dict from labels to

--- a/nixpkgs/toolchains/go.bzl
+++ b/nixpkgs/toolchains/go.bzl
@@ -1,3 +1,12 @@
+"""Rules for importing a Go toolchain from Nixpkgs.
+
+**NOTE: The following rules must be loaded from
+`@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl` to avoid unnecessary
+dependencies on rules_go for those who don't need go toolchain.
+`io_bazel_rules_go` must be available for loading before loading of
+`@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl`.**
+"""
+
 load(
     "@io_bazel_rules_go//go:deps.bzl",
     "go_wrap_sdk",
@@ -15,15 +24,88 @@ def nixpkgs_go_configure(
         nix_file_deps = None,
         nix_file_content = None,
         nixopts = []):
-    """
-    Use go toolchain from Nixpkgs. Will fail if not a nix-based platform.
+    """Use go toolchain from Nixpkgs. Will fail if not a nix-based platform.
 
-    By default rules_go configures go toolchain to be downloaded as binaries (which doesn't work on NixOS),
+    By default rules_go configures the go toolchain to be downloaded as binaries (which doesn't work on NixOS),
     there is a way to tell rules_go to look into environment and find local go binary which is not hermetic.
     This command allows to setup hermetic go sdk from Nixpkgs, which should be considerate as best practice.
 
-    Note that nix package must provide full go sdk at the root of package instead of in $out/share/go
-    And also provide an empty normal file named PACKAGE_ROOT at the root of package
+    Note that the nix package must provide a full go sdk at the root of the package instead of in `$out/share/go`,
+    and also provide an empty normal file named `PACKAGE_ROOT` at the root of package.
+
+    #### Example
+
+      ```bzl
+      nixpkgs_go_configure(repository = "@nixpkgs//:default.nix")
+      ```
+
+      Example (optional nix support when go is a transitive dependency):
+
+      ```bzl
+      # .bazel-lib/nixos-support.bzl
+      def _has_nix(ctx):
+          return ctx.which("nix-build") != None
+
+      def _gen_imports_impl(ctx):
+          ctx.file("BUILD", "")
+
+          imports_for_nix = \"""
+              load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl", "nixpkgs_go_toolchain")
+
+              def fix_go():
+                  nixpkgs_go_toolchain(repository = "@nixpkgs")
+          \"""
+          imports_for_non_nix = \"""
+              def fix_go():
+                  # if go isn't transitive you'll need to add call to go_register_toolchains here
+                  pass
+          \"""
+
+          if _has_nix(ctx):
+              ctx.file("imports.bzl", imports_for_nix)
+          else:
+              ctx.file("imports.bzl", imports_for_non_nix)
+
+      _gen_imports = repository_rule(
+          implementation = _gen_imports_impl,
+          attrs = dict(),
+      )
+
+      def gen_imports():
+          _gen_imports(
+              name = "nixos_support",
+          )
+
+      # WORKSPACE
+
+      // ...
+      http_archive(name = "io_tweag_rules_nixpkgs", ...)
+      // ...
+      local_repository(
+          name = "bazel_lib",
+          path = ".bazel-lib",
+      )
+      load("@bazel_lib//:nixos-support.bzl", "gen_imports")
+      gen_imports()
+      load("@nixos_support//:imports.bzl", "fix_go")
+      fix_go()
+      ```
+
+    Args:
+      sdk_name: Go sdk name to pass to rules_go
+      nix_file: An expression for a Nix environment derivation. The environment should expose the whole go SDK (`bin`, `src`, ...) at the root of package. It also must contain a `PACKAGE_ROOT` file in the root of pacakge.
+      nix_file_deps: Dependencies of `nix_file` if any.
+      nix_file_content: An expression for a Nix environment derivation.
+      repository: A repository label identifying which Nixpkgs to use. Equivalent to `repositories = { "nixpkgs": ...}`.
+      repositories: A dictionary mapping `NIX_PATH` entries to repository labels.
+
+        Setting it to
+        ```
+        repositories = { "myrepo" : "//:myrepo" }
+        ```
+        for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) in the nix manual for more information.
+
+        Specify one of `path` or `repositories`.
     """
 
     if not nix_file and not nix_file_content:

--- a/shell.nix
+++ b/shell.nix
@@ -9,5 +9,6 @@ mkShell {
     gcc
     nix
     git
+    jdk11
   ];
 }


### PR DESCRIPTION
Closes #138 

* Extends the docstrings of the various rules to match the documentation in the project README.
* Updates rules_go for stardoc compatibility, see https://github.com/bazelbuild/rules_go/pull/2620.
* Defines `stardoc` targets for `nixpkgs/nixpkgs.bzl` and `nixpkgs/toolchains/go.bzl`.
* Defines a README template that can be used to generate the project README by substituting Stardoc generated documentation.
* Defines automation to update the project README and check that it is up-to-date on CI.
* Updates the project README.