### PR TITLE
Support clang on Linux in hermetic cc toolchain 

### DIFF
--- a/nixpkgs/toolchains/cc.nix
+++ b/nixpkgs/toolchains/cc.nix
@@ -160,7 +160,10 @@ in
         # Keep stack frames for debugging, even in opt mode.
         -fno-omit-frame-pointer
       )
-      CXX_FLAGS=(-std=c++0x)
+      CXX_FLAGS=(
+        -x c++
+        -std=c++0x
+      )
       LINK_FLAGS=(
         $(
           if [[ -x ${cc}/bin/ld.gold ]]; then echo -fuse-ld=gold; fi
@@ -176,10 +179,11 @@ in
           # Have gcc return the exit code from ld.
           add_compiler_option_if_supported -pass-exit-codes
         )
+      )
+      LINK_LIBS=(
         -lstdc++
         -lm
       )
-      LINK_LIBS=()
       OPT_COMPILE_FLAGS=(
         # No debug symbols.
         # Maybe we should enable https://gcc.gnu.org/wiki/DebugFission for opt or

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -82,6 +82,11 @@ cc_binary(
     srcs = ["cc-test.cc"],
 )
 
+cc_binary(
+    name = "c-test",
+    srcs = ["c-test.c"],
+)
+
 # Test that nixpkgs_cc_configure is selected.
 cc_toolchain_test(
     name = "cc-toolchain",

--- a/tests/c-test.c
+++ b/tests/c-test.c
@@ -1,0 +1,7 @@
+#include "stdio.h"
+int main() {
+        puts("Hello world\n");
+        // Ensure that this is compiled as C, template is a keyword in C++.
+        int template = 0;
+        return template;
+}

--- a/tests/cc-test.cc
+++ b/tests/cc-test.cc
@@ -1,1 +1,5 @@
-int main() { return 0; }
+#include <iostream>
+int main() {
+        std::cout << "Hello world\n";
+        return 0;
+}


### PR DESCRIPTION
Closes #147 

Adds a test-case for C compilation and makes the CC test C++ specific.
Adds the required flags for a clang toolchain on Linux.

See https://github.com/tweag/rules_nixpkgs/pull/128#issuecomment-732941362