### PR TITLE
Bazel 3.7.2

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,9 +33,9 @@ stardoc_repositories()
 
 # For tests
 
-load("@bazel_skylib//lib:unittest.bzl", "register_unittest_toolchains")
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
-register_unittest_toolchains()
+bazel_skylib_workspace()
 
 nixpkgs_git_repository(
     name = "remote_nixpkgs",
@@ -241,12 +241,10 @@ sh_posix_configure()
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "c024f8272a6042b5a438fbc56a673ec1c839241980aa695ab3fcf6ecc40e69d8",
-    strip_prefix = "rules_go-2bada599e10349d42e369cab1ec4f4679f148598",
+    sha256 = "7904dbecbaffd068651916dce77ff3437679f9d20e1a7956bff43826e7645fcc",
     urls = [
-        # XXX: Update once a release is available that includes
-        # https://github.com/bazelbuild/rules_go/pull/2621
-        "https://github.com/bazelbuild/rules_go/archive/2bada599e10349d42e369cab1ec4f4679f148598.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.25.1/rules_go-v0.25.1.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.25.1/rules_go-v0.25.1.tar.gz",
     ],
 )
 

--- a/nixpkgs.json
+++ b/nixpkgs.json
@@ -2,6 +2,6 @@
   "owner": "NixOS",
   "repo": "nixpkgs",
   "branch": "nixpkgs-unstable",
-  "rev": "752b6a95db93f03d6901304f760bd452b4b7db41",
-  "sha256": "16vxh0bj9qx9x4pncax3bl8z1awy20dcw5xqk01znay8qyml73w5"
+  "rev": "24e5fe6075bc7a137bb701eb8a378f5a8689e10d",
+  "sha256": "1bkjh566r1bpbddz6fjhccn872p1dlvg5fwq9j2qdj4b5q2pmljc"
 }

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,5 +1,5 @@
 let
-  # nixpkgs-unstable as of 2020-07-09
+  # nixpkgs-unstable as of 2021-02-04
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/nixpkgs/repositories.bzl
+++ b/nixpkgs/repositories.bzl
@@ -6,14 +6,18 @@ def rules_nixpkgs_dependencies():
     maybe(
         http_archive,
         "platforms",
-        sha256 = "23566db029006fe23d8140d14514ada8c742d82b51973b4d331ee423c75a0bfa",
-        strip_prefix = "platforms-46993efdd33b73649796c5fc5c9efb193ae19d51",
-        urls = ["https://github.com/bazelbuild/platforms/archive/46993efdd33b73649796c5fc5c9efb193ae19d51.tar.gz"],
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.3/platforms-0.0.3.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.3/platforms-0.0.3.tar.gz",
+        ],
+        sha256 = "460caee0fa583b908c622913334ec3c1b842572b9c23cf0d3da0c2543a1a157d",
     )
     maybe(
         http_archive,
         "bazel_skylib",
-        sha256 = "e5d90f0ec952883d56747b7604e2a15ee36e288bb556c3d0ed33e818a4d971f2",
-        strip_prefix = "bazel-skylib-1.0.2",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/1.0.2.tar.gz"],
+        urls = [
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+        ],
+        sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
     )


### PR DESCRIPTION
Update Bazel from version 3.3.1 to 3.7.2.
Updates the nixpkgs revision accordingly.
Updates rules_nixpkgs dependencies to latest released versions.