### PR TITLE
Include llvm-cov in tools

### DIFF
--- a/nixpkgs/toolchains/cc.nix
+++ b/nixpkgs/toolchains/cc.nix
@@ -68,7 +68,7 @@ in
       # Determine toolchain tool paths.
       #
       # If a tool is not available then we use `bin/false` as a stand-in.
-      declare -A TOOLS=( [ar]=ar [cpp]=cpp [dwp]=dwp [gcc]=cc [gcov]=gcov [ld]=ld [nm]=nm [objcopy]=objcopy [objdump]=objdump [strip]=strip )
+      declare -A TOOLS=( [ar]=ar [cpp]=cpp [dwp]=dwp [gcc]=cc [gcov]=gcov [llvm-cov]=llvm-cov [ld]=ld [nm]=nm [objcopy]=objcopy [objdump]=objdump [strip]=strip )
       TOOL_NAMES=(''${!TOOLS[@]})
       declare -A TOOL_PATHS=()
       for tool_name in ''${!TOOLS[@]}; do


### PR DESCRIPTION
This seems to be required in Bazel 4.0.0. With this change, CI on the
daml repo is passing on Linux at least (haven’t been able to test on
MacOS for unrelated reasons).