### PR TITLE
Docs nixpkgs_go_toolchain --> *_configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ rules_nixpkgs_dependencies()
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository", "nixpkgs_package", "nixpkgs_cc_toolchain")
 
-load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl", "nixpkgs_go_toolchain") # optional
+load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl", "nixpkgs_go_configure") # optional
 ```
 
 If you use `rules_nixpkgs` to configure a toolchain then you will also need to
@@ -1070,10 +1070,10 @@ and also provide an empty normal file named `PACKAGE_ROOT` at the root of packag
       ctx.file("BUILD", "")
 
       imports_for_nix = """
-          load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl", "nixpkgs_go_toolchain")
+          load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl", "nixpkgs_go_configure")
 
           def fix_go():
-              nixpkgs_go_toolchain(repository = "@nixpkgs")
+              nixpkgs_go_configure(repository = "@nixpkgs")
       """
       imports_for_non_nix = """
           def fix_go():

--- a/docs/README.md.tpl
+++ b/docs/README.md.tpl
@@ -48,7 +48,7 @@ rules_nixpkgs_dependencies()
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository", "nixpkgs_package", "nixpkgs_cc_toolchain")
 
-load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl", "nixpkgs_go_toolchain") # optional
+load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl", "nixpkgs_go_configure") # optional
 ```
 
 If you use `rules_nixpkgs` to configure a toolchain then you will also need to

--- a/nixpkgs/toolchains/go.bzl
+++ b/nixpkgs/toolchains/go.bzl
@@ -50,10 +50,10 @@ def nixpkgs_go_configure(
           ctx.file("BUILD", "")
 
           imports_for_nix = \"""
-              load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl", "nixpkgs_go_toolchain")
+              load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl", "nixpkgs_go_configure")
 
               def fix_go():
-                  nixpkgs_go_toolchain(repository = "@nixpkgs")
+                  nixpkgs_go_configure(repository = "@nixpkgs")
           \"""
           imports_for_non_nix = \"""
               def fix_go():


### PR DESCRIPTION
Closes #155 

https://github.com/tweag/rules_nixpkgs/pull/107 introduced `nizpkgs_go_configure`. The docs changes in that PR reference `nixpkgs_go_toolchain` in some instances, which does not exist. This PR changes those to reference `nixpkgs_go_configure` instead.