### PR TITLE
Update bazel 3.7.2 --> 4.0.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -241,10 +241,10 @@ sh_posix_configure()
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "7904dbecbaffd068651916dce77ff3437679f9d20e1a7956bff43826e7645fcc",
+    sha256 = "7c10271940c6bce577d51a075ae77728964db285dac0a46614a7934dc34303e6",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.25.1/rules_go-v0.25.1.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.25.1/rules_go-v0.25.1.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.26.0/rules_go-v0.26.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.26.0/rules_go-v0.26.0.tar.gz",
     ],
 )
 

--- a/nixpkgs.json
+++ b/nixpkgs.json
@@ -2,6 +2,6 @@
   "owner": "NixOS",
   "repo": "nixpkgs",
   "branch": "nixpkgs-unstable",
-  "rev": "24e5fe6075bc7a137bb701eb8a378f5a8689e10d",
-  "sha256": "1bkjh566r1bpbddz6fjhccn872p1dlvg5fwq9j2qdj4b5q2pmljc"
+  "rev": "ad4db3f4d8ae54482c63c31c14921cb73953548d",
+  "sha256": "1fwl898f6wznkjpwq11brgadz6iff5w5f4lwj2l7ax2rz7r03mnn"
 }

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,5 +1,5 @@
 let
-  # nixpkgs-unstable as of 2021-02-04
+  # nixpkgs-unstable as of 2021-02-19
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/nixpkgs/repositories.bzl
+++ b/nixpkgs/repositories.bzl
@@ -7,10 +7,10 @@ def rules_nixpkgs_dependencies():
         http_archive,
         "platforms",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.3/platforms-0.0.3.tar.gz",
-            "https://github.com/bazelbuild/platforms/releases/download/0.0.3/platforms-0.0.3.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz",
         ],
-        sha256 = "460caee0fa583b908c622913334ec3c1b842572b9c23cf0d3da0c2543a1a157d",
+        sha256 = "079945598e4b6cc075846f7fd6a9d0857c33a7afc0de868c2ccb96405225135d",
     )
     maybe(
         http_archive,

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@ with pkgs;
 
 mkShell {
   buildInputs = [
-    bazel
+    bazel_4
     cacert
     gcc
     nix


### PR DESCRIPTION
- Updates the nixpkgs revision
- Updates Bazel to 4.0.0
- Updates dependencies where new releases are available.