### PR TITLE
Migrate to GitHub actions & add MacOS pipeline

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,3 +5,18 @@ build --crosstool_top=@nixpkgs_config_cc//:toolchain
 # resolved before `--incompatible_enable_cc_toolchain_resolution` can be
 # recommended for `nixpkgs_cc_configure_hermetic`.
 # build --incompatible_enable_cc_toolchain_resolution
+
+# CI Configuration
+# ----------------
+common:ci --color=no
+build:ci --verbose_failures
+test:ci --test_output=errors
+
+# Use a remote cache during CI
+build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
+build:ci --bes_backend=grpcs://cloud.buildbuddy.io
+build:ci --remote_cache=grpcs://cloud.buildbuddy.io
+build:ci --remote_timeout=3600
+# Avoid failures of the form `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED`.
+# See https://github.com/tweag/rules_haskell/issues/1498.
+build:ci --keep_backend_build_event_connections_alive=false

--- a/.bazelrc
+++ b/.bazelrc
@@ -20,3 +20,7 @@ build:ci --remote_timeout=3600
 # Avoid failures of the form `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED`.
 # See https://github.com/tweag/rules_haskell/issues/1498.
 build:ci --keep_backend_build_event_connections_alive=false
+
+# User Configuration
+# ------------------
+try-import %workspace%/.bazelrc.local

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,0 @@
-steps:
-  - label: "Run tests"
-    command: |
-      nix-shell --pure --run 'bazel test --test_output errors //...'
-    timeout: 100

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,0 +1,29 @@
+name: Continuous integration
+on: [push]
+jobs:
+  test-nixpkgs:
+    name: Build & Test - Nixpkgs
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos]
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=./nixpkgs.nix
+      - name: Configure
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          cat >.bazelrc.local <<EOF
+          common --config=ci
+          build --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
+          EOF
+      - name: Build & test
+        run: |
+          nix-shell --pure --run '
+            set -euo pipefail
+            bazel test //...
+          '

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,8 @@
 pull_request_rules:
   - name: automatic merge
     conditions:
-      - "status-success~=buildkite/rules-nixpkgs(|/pr)"
+      - 'status-success~=Build & Test - Nixpkgs \(ubuntu\).*'
+      - 'status-success~=Build & Test - Nixpkgs \(macos\).*'
       - "#approved-reviews-by>=1"
       - "label=merge-queue"
       - "base=master"
@@ -25,4 +26,3 @@ pull_request_rules:
       label:
         remove:
           - "merge-queue"
-

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -134,6 +134,7 @@ sh_test(
         "//conditions:default": [],
     }),
     target_compatible_with = [
+        # busybox_static is not available on MacOS.
         "@platforms//os:linux",
     ],
 )

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -128,7 +128,12 @@ sh_test(
     data = [
         "//nixpkgs:srcs",
         "//tests/invalid_nixpkgs_package:srcs",
-        "@busybox_static//:bin",
         "@nix-unstable//:bin",
+    ] + select({
+        "@platforms//os:linux": ["@busybox_static//:bin"],
+        "//conditions:default": [],
+    }),
+    target_compatible_with = [
+        "@platforms//os:linux",
     ],
 )


### PR DESCRIPTION
depends on #157

- Adds GitHub actions CI workflows for Linux and MacOS (based on the configuration in rules_haskell)
    All tests worked on MacOS right away apart from the one using busybox - the Nix derivation is not-supported on MacOS.
- Adds CI configuration in `.bazelrc`
- Configures BuildBuddy remote cache and build event protocol on CI
- Removes the buildkite configuration
- Updates the Mergify configuration