### PR TITLE
Avoid binary file corruption in nixpkgs_local_repository

### DIFF
--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -1210,7 +1210,7 @@ def _cp(repository_ctx, src, dest = None):
     # It means that executable files will miss the bit and won't be executable.
     # Forcing it to True will fix this behavior, but will impact a lot of file
     # (most of the time, files do not have the executable bit) and this may
-    # lead to other errors in the next process are checking for executable bit.
+    # lead to other errors if the next process is checking the executable bit.
     # One other side effect of this change is that you will have a difference
     # in the nix hash computed when nix is run by rules_nixpkgs or directly.
     repository_ctx.file(repository_ctx.path(dest),

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -1203,7 +1203,21 @@ def _cp(repository_ctx, src, dest = None):
             for component in [src.workspace_root, src.package, src.name]
             if component
         ])
-    repository_ctx.template(dest, src, executable = False)
+
+    # Copy the file
+    # TODO: auto detect the executable bit of the source file
+    # It is set to False (i.e. not executable) which was the previous behavior.
+    # It means that executable files will miss the bit and won't be executable.
+    # Forcing it to True will fix this behavior, but will impact a lot of file
+    # (most of the time, files do not have the executable bit) and this may
+    # lead to other errors in the next process are checking for executable bit.
+    # One other side effect of this change is that you will have a difference
+    # in the nix hash computed when nix is run by rules_nixpkgs or directly.
+    repository_ctx.file(repository_ctx.path(dest),
+                        repository_ctx.read(repository_ctx.path(src)),
+                        executable=False,
+                        legacy_utf8=False)
+
     return dest
 
 def _label_string(label):


### PR DESCRIPTION
This closes #136

`repository_ctx` is meant to work on "text" files and does text encoding
and decoding, which breaks in the context of a binary file.

There is no `cp` API in repository_ctx, as suggested in
https://github.com/bazelbuild/bazel/issues/11858, but
https://github.com/bazelbuild/bazel/issues/11857 suggested to use this
approach with `repository_ctx.file`.