### PR TITLE
Copy the executable bit

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,15 +1,15 @@
 queue_rules:
   - name: default
     conditions:
-      - check-success=Build & Test - Nixpkgs (*)
-      - check-success=Build & Test - Examples (*)
+      - check-success~=Build & Test - Nixpkgs \(.*\)
+      - check-success~=Build & Test - Examples \(.*\)
 
 pull_request_rules:
   - name: merge using the merge queue
     conditions:
       - base=master
-      - check-success=Build & Test - Nixpkgs (*)
-      - check-success=Build & Test - Examples (*)
+      - check-success~=Build & Test - Nixpkgs \(.*\)
+      - check-success~=Build & Test - Examples \(.*\)
       - "#approved-reviews-by>=1"
     actions:
       queue:

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -1397,10 +1397,12 @@ def _cp(repository_ctx, src, dest = None):
 
     # Copy the executable bit of the source
     # This is important to ensure that copied binaries are executable.
-    repository_ctx.execute([repository_ctx.which("chmod"),
-                            "--reference",
-                            repository_ctx.path(src),
-                            repository_ctx.path(dest)])
+    repository_ctx.execute([
+        repository_ctx.which("chmod"),
+        "--reference",
+        repository_ctx.path(src),
+        repository_ctx.path(dest),
+    ])
 
     return dest
 

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -1388,20 +1388,19 @@ def _cp(repository_ctx, src, dest = None):
         ])
 
     # Copy the file
-    # TODO: auto detect the executable bit of the source file
-    # It is set to False (i.e. not executable) which was the previous behavior.
-    # It means that executable files will miss the bit and won't be executable.
-    # Forcing it to True will fix this behavior, but will impact a lot of file
-    # (most of the time, files do not have the executable bit) and this may
-    # lead to other errors if the next process is checking the executable bit.
-    # One other side effect of this change is that you will have a difference
-    # in the nix hash computed when nix is run by rules_nixpkgs or directly.
     repository_ctx.file(
         repository_ctx.path(dest),
         repository_ctx.read(repository_ctx.path(src)),
         executable = False,
         legacy_utf8 = False,
     )
+
+    # Copy the executable bit of the source
+    # This is important to ensure that copied binaries are executable.
+    repository_ctx.execute([repository_ctx.which("chmod"),
+                            "--reference",
+                            repository_ctx.path(src),
+                            repository_ctx.path(dest)])
 
     return dest
 

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -1397,12 +1397,14 @@ def _cp(repository_ctx, src, dest = None):
 
     # Copy the executable bit of the source
     # This is important to ensure that copied binaries are executable.
-    repository_ctx.execute([
-        repository_ctx.which("chmod"),
-        "--reference",
-        repository_ctx.path(src),
-        repository_ctx.path(dest),
-    ])
+    # Windows may not have chmod in path and doesn't have executable bits anyway.
+    if get_cpu_value(repository_ctx) != "x64_windows":
+        repository_ctx.execute([
+            repository_ctx.which("chmod"),
+            "--reference",
+            repository_ctx.path(src),
+            repository_ctx.path(dest),
+        ])
 
     return dest
 


### PR DESCRIPTION
Closes #160 

Copy the executable bit of files required by `nix_file_deps` in order to ensure that executable binaries can still be executed.