### PR TITLE
add fail_not_supported to nixpkgs_go_configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1070,17 +1070,18 @@ dependencies on rules_go for those who don't need go toolchain.
 
 <pre>
 nixpkgs_go_configure(<a href="#nixpkgs_go_configure-sdk_name">sdk_name</a>, <a href="#nixpkgs_go_configure-repository">repository</a>, <a href="#nixpkgs_go_configure-repositories">repositories</a>, <a href="#nixpkgs_go_configure-nix_file">nix_file</a>, <a href="#nixpkgs_go_configure-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_go_configure-nix_file_content">nix_file_content</a>,
-                     <a href="#nixpkgs_go_configure-nixopts">nixopts</a>)
+                     <a href="#nixpkgs_go_configure-nixopts">nixopts</a>, <a href="#nixpkgs_go_configure-fail_not_supported">fail_not_supported</a>, <a href="#nixpkgs_go_configure-quiet">quiet</a>)
 </pre>
 
-Use go toolchain from Nixpkgs. Will fail if not a nix-based platform.
+Use go toolchain from Nixpkgs.
 
 By default rules_go configures the go toolchain to be downloaded as binaries (which doesn't work on NixOS),
 there is a way to tell rules_go to look into environment and find local go binary which is not hermetic.
-This command allows to setup hermetic go sdk from Nixpkgs, which should be considerate as best practice.
+This command allows to setup a hermetic go sdk from Nixpkgs, which should be considered as best practice.
+Cross toolchains are declared and registered for each entry in the `PLATFORMS` constant in `rules_go`.
 
 Note that the nix package must provide a full go sdk at the root of the package instead of in `$out/share/go`,
-and also provide an empty normal file named `PACKAGE_ROOT` at the root of package.
+and also provide an empty normal file named `ROOT` at the root of package.
 
 #### Example
 
@@ -1192,7 +1193,7 @@ A dictionary mapping `NIX_PATH` entries to repository labels.
   ```
   repositories = { "myrepo" : "//:myrepo" }
   ```
-  for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) in the nix manual for more information.
+  for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) for more information.
 
   Specify one of `path` or `repositories`.
 
@@ -1208,7 +1209,7 @@ default is <code>None</code>
 
 <p>
 
-An expression for a Nix environment derivation. The environment should expose the whole go SDK (`bin`, `src`, ...) at the root of package. It also must contain a `PACKAGE_ROOT` file in the root of pacakge.
+An expression for a Nix environment derivation. The environment should expose the whole go SDK (`bin`, `src`, ...) at the root of package. It also must contain a `ROOT` file in the root of pacakge.
 
 </p>
 </td>
@@ -1248,6 +1249,34 @@ An expression for a Nix environment derivation.
 optional.
 default is <code>[]</code>
 
+</td>
+</tr>
+<tr id="nixpkgs_go_configure-fail_not_supported">
+<td><code>fail_not_supported</code></td>
+<td>
+
+optional.
+default is <code>True</code>
+
+<p>
+
+See [`nixpkgs_package`](#nixpkgs_package-fail_not_supported).
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_go_configure-quiet">
+<td><code>quiet</code></td>
+<td>
+
+optional.
+default is <code>False</code>
+
+<p>
+
+Whether to hide the output of the Nix command.
+
+</p>
 </td>
 </tr>
 </tbody>

--- a/nixpkgs/toolchains/go.bzl
+++ b/nixpkgs/toolchains/go.bzl
@@ -7,14 +7,225 @@ dependencies on rules_go for those who don't need go toolchain.
 `@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl`.**
 """
 
-load(
-    "@io_bazel_rules_go//go:deps.bzl",
-    "go_wrap_sdk",
+load("//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
+load("@bazel_tools//tools/cpp:lib_cc_configure.bzl", "get_cpu_value")
+load("@io_bazel_rules_go//go/private:platforms.bzl", "PLATFORMS")
+
+def _detect_host_platform(ctx):
+    """Copied from `rules_go`, since we have no other way to determine the proper `goarch` value.
+    https://github.com/bazelbuild/rules_go/blob/728a9e1874bc965b05c415d7f6b332a86ac35102/go/private/sdk.bzl#L239
+    """
+    if ctx.os.name == "linux":
+        goos, goarch = "linux", "amd64"
+        res = ctx.execute(["uname", "-p"])
+        if res.return_code == 0:
+            uname = res.stdout.strip()
+            if uname == "s390x":
+                goarch = "s390x"
+            elif uname == "i686":
+                goarch = "386"
+
+        # uname -p is not working on Aarch64 boards
+        # or for ppc64le on some distros
+        res = ctx.execute(["uname", "-m"])
+        if res.return_code == 0:
+            uname = res.stdout.strip()
+            if uname == "aarch64":
+                goarch = "arm64"
+            elif uname == "armv6l":
+                goarch = "arm"
+            elif uname == "armv7l":
+                goarch = "arm"
+            elif uname == "ppc64le":
+                goarch = "ppc64le"
+
+        # Default to amd64 when uname doesn't return a known value.
+
+    elif ctx.os.name == "mac os x":
+        goos, goarch = "darwin", "amd64"
+
+        res = ctx.execute(["uname", "-m"])
+        if res.return_code == 0:
+            uname = res.stdout.strip()
+            if uname == "arm64":
+                goarch = "arm64"
+
+        # Default to amd64 when uname doesn't return a known value.
+
+    elif ctx.os.name.startswith("windows"):
+        goos, goarch = "windows", "amd64"
+    elif ctx.os.name == "freebsd":
+        goos, goarch = "freebsd", "amd64"
+    else:
+        fail("Unsupported operating system: " + ctx.os.name)
+
+    return goos, goarch
+
+go_helpers_build = """
+load("@io_bazel_rules_go//go:def.bzl", "go_sdk")
+
+def go_sdk_for_arch():
+    native.filegroup(
+        name = "libs",
+        srcs = native.glob(
+            ["pkg/{goos}_{goarch}/**/*.a"],
+            exclude = ["pkg/{goos}_{goarch}/**/cmd/**"],
+        ),
+    )
+
+    go_sdk(
+        name = "go_sdk",
+        goos = "{goos}",
+        goarch = "{goarch}",
+        root_file = "ROOT",
+        package_list = ":package_list",
+        libs = [":libs"],
+        headers = [":headers"],
+        srcs = [":srcs"],
+        tools = [":tools"],
+        go = "bin/go{exe}",
+    )
+"""
+
+def _nixpkgs_go_helpers_impl(repository_ctx):
+    repository_ctx.file("BUILD.bazel", executable = False, content = "")
+    goos, goarch = _detect_host_platform(repository_ctx)
+    content = go_helpers_build.format(
+        goos = goos,
+        goarch = goarch,
+        exe = ".exe" if goos == "windows" else "",
+    )
+    repository_ctx.file("go_sdk.bzl", executable = False, content = content)
+
+nixpkgs_go_helpers = repository_rule(
+    implementation = _nixpkgs_go_helpers_impl
 )
-load(
-    "//nixpkgs:nixpkgs.bzl",
-    "nixpkgs_package",
+
+go_toolchain_func = """
+load("@io_bazel_rules_go//go/private:platforms.bzl", "PLATFORMS")
+load("@io_bazel_rules_go//go:def.bzl", "go_toolchain")
+
+def declare_toolchains(host_goos, host_goarch):
+    for p in [p for p in PLATFORMS if not p.cgo]:
+        link_flags = []
+        cgo_link_flags = []
+        if host_goos == "darwin":
+            cgo_link_flags.extend(["-shared", "-Wl,-all_load"])
+        if host_goos == "linux":
+            cgo_link_flags.append("-Wl,-whole-archive")
+        toolchain_name = "toolchain_go_" + p.name
+        impl_name = toolchain_name + "-impl"
+        cgo_constraints = (
+            "@io_bazel_rules_go//go/toolchain:cgo_off",
+            "@io_bazel_rules_go//go/toolchain:cgo_on",
+        )
+        constraints = [c for c in p.constraints if c not in cgo_constraints]
+        go_toolchain(
+            name = impl_name,
+            goos = p.goos,
+            goarch = p.goarch,
+            sdk = "@{sdk_repo}//:go_sdk",
+            builder = "@{sdk_repo}//:builder",
+            link_flags = link_flags,
+            cgo_link_flags = cgo_link_flags,
+            visibility = ["//visibility:public"],
+        )
+        native.toolchain(
+            name = toolchain_name,
+            toolchain_type = "@io_bazel_rules_go//go:toolchain",
+            exec_compatible_with = [
+                "@io_bazel_rules_go//go/toolchain:" + host_goos,
+                "@io_bazel_rules_go//go/toolchain:" + host_goarch,
+                "@io_tweag_rules_nixpkgs//nixpkgs/constraints:support_nix",
+            ],
+            target_compatible_with = constraints,
+            toolchain = ":" + impl_name,
+        )
+"""
+
+go_toolchain_build = """
+load("//:toolchain.bzl", "declare_toolchains")
+
+declare_toolchains("{goos}", "{goarch}")
+"""
+
+def _nixpkgs_go_toolchain_impl(repository_ctx):
+    cpu = get_cpu_value(repository_ctx)
+    goos, goarch = _detect_host_platform(repository_ctx)
+    content = go_toolchain_func.format(
+        sdk_repo = repository_ctx.attr.sdk_repo,
+    )
+    build_content = go_toolchain_build.format(
+        goos = goos,
+        goarch = goarch,
+    )
+    repository_ctx.file("toolchain.bzl", executable = False, content = content)
+    repository_ctx.file("BUILD.bazel", executable = False, content = build_content)
+
+nixpkgs_go_toolchain = repository_rule(
+    implementation = _nixpkgs_go_toolchain_impl,
+    attrs = {
+        "sdk_repo": attr.string(
+            doc = "name of the nixpkgs_package repository defining the go sdk"
+        ),
+    },
+    doc = """
+    Set up the Go SDK
+    """
 )
+
+go_sdk_build = """
+load("@io_bazel_rules_go//go/private/rules:binary.bzl", "go_tool_binary")
+load("@io_bazel_rules_go//go/private/rules:sdk.bzl", "package_list")
+load("@io_bazel_rules_go//go:def.bzl", "go_sdk")
+load("@{helpers}//:go_sdk.bzl", "go_sdk_for_arch")
+
+package(default_visibility = ["//visibility:public"])
+
+go_sdk_for_arch()
+
+filegroup(
+    name = "headers",
+    srcs = glob(["pkg/include/*.h"]),
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["src/**"]),
+)
+
+filegroup(
+    name = "tools",
+    srcs = glob(["pkg/tool/**", "bin/gofmt*"])
+)
+
+go_tool_binary(
+    name = "builder",
+    srcs = ["@io_bazel_rules_go//go/tools/builders:builder_srcs"],
+    sdk = ":go_sdk",
+)
+
+package_list(
+    name = "package_list",
+    srcs = [":srcs"],
+    root_file = "ROOT",
+    out = "packages.txt",
+)
+
+filegroup(
+    name = "files",
+    srcs = glob([
+        "bin/go*",
+        "src/**",
+        "pkg/**",
+    ]),
+)
+
+exports_files(
+    ["lib/time/zoneinfo.zip"],
+    visibility = ["//visibility:public"],
+)
+"""
 
 def nixpkgs_go_configure(
         sdk_name = "go_sdk",
@@ -23,15 +234,19 @@ def nixpkgs_go_configure(
         nix_file = None,
         nix_file_deps = None,
         nix_file_content = None,
-        nixopts = []):
-    """Use go toolchain from Nixpkgs. Will fail if not a nix-based platform.
+        nixopts = [],
+        fail_not_supported = True,
+        quiet = False,
+        ):
+    """Use go toolchain from Nixpkgs.
 
     By default rules_go configures the go toolchain to be downloaded as binaries (which doesn't work on NixOS),
     there is a way to tell rules_go to look into environment and find local go binary which is not hermetic.
-    This command allows to setup hermetic go sdk from Nixpkgs, which should be considerate as best practice.
+    This command allows to setup a hermetic go sdk from Nixpkgs, which should be considered as best practice.
+    Cross toolchains are declared and registered for each entry in the `PLATFORMS` constant in `rules_go`.
 
     Note that the nix package must provide a full go sdk at the root of the package instead of in `$out/share/go`,
-    and also provide an empty normal file named `PACKAGE_ROOT` at the root of package.
+    and also provide an empty normal file named `ROOT` at the root of package.
 
     #### Example
 
@@ -93,7 +308,7 @@ def nixpkgs_go_configure(
 
     Args:
       sdk_name: Go sdk name to pass to rules_go
-      nix_file: An expression for a Nix environment derivation. The environment should expose the whole go SDK (`bin`, `src`, ...) at the root of package. It also must contain a `PACKAGE_ROOT` file in the root of pacakge.
+      nix_file: An expression for a Nix environment derivation. The environment should expose the whole go SDK (`bin`, `src`, ...) at the root of package. It also must contain a `ROOT` file in the root of pacakge.
       nix_file_deps: Dependencies of `nix_file` if any.
       nix_file_content: An expression for a Nix environment derivation.
       repository: A repository label identifying which Nixpkgs to use. Equivalent to `repositories = { "nixpkgs": ...}`.
@@ -103,9 +318,11 @@ def nixpkgs_go_configure(
         ```
         repositories = { "myrepo" : "//:myrepo" }
         ```
-        for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) in the nix manual for more information.
+        for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) for more information.
 
         Specify one of `path` or `repositories`.
+      fail_not_supported: See [`nixpkgs_package`](#nixpkgs_package-fail_not_supported).
+      quiet: Whether to hide the output of the Nix command.
     """
 
     if not nix_file and not nix_file_content:
@@ -116,21 +333,34 @@ def nixpkgs_go_configure(
                 go
               ];
               postBuild = ''
-                touch $out/PACKAGE_ROOT
+                touch $out/ROOT
                 ln -s $out/share/go/{api,doc,lib,misc,pkg,src} $out/
               '';
             }
         """
 
+    helpers_repo = sdk_name + "_helpers"
+    nixpkgs_go_helpers(
+        name = helpers_repo,
+    )
     nixpkgs_package(
-        name = "nixpkgs_go_toolchain",
+        name = sdk_name,
         repository = repository,
         repositories = repositories,
         nix_file = nix_file,
         nix_file_deps = nix_file_deps,
         nix_file_content = nix_file_content,
-        build_file_content = """exports_files(glob(["**/*"]))""",
+        build_file_content = go_sdk_build.format(
+            helpers = helpers_repo,
+        ),
         nixopts = nixopts,
+        fail_not_supported = fail_not_supported,
+        quiet = quiet,
     )
-
-    go_wrap_sdk(name = sdk_name, root_file = "@nixpkgs_go_toolchain//:PACKAGE_ROOT")
+    toolchains_repo = sdk_name + "_toolchains"
+    nixpkgs_go_toolchain(
+        name = toolchains_repo,
+        sdk_repo = sdk_name,
+    )
+    for p in [p for p in PLATFORMS if not p.cgo]:
+        native.register_toolchains("@{}//:toolchain_go_{}".format(toolchains_repo, p.name))


### PR DESCRIPTION
Passing through the `fail_not_supported` flag to `nixpkgs_package` is trivial, but that alone will cause the `go_wrap_sdk` to fail.
I created another repo rule to wrap that call, in which I use `_is_supported_platform` directly, and which I then call from `nixpkgs_go_configure`.

Problem now is that it seems this repo rule isn't executed at all. Some advice would be appreciated.

Furthermore, I placed the wrapper rule in `nixpkgs.bzl`, because `_is_supported_platform` is private to this file. Is that reasonable?