### PR TITLE
Add nixpkgs_java_configure

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,10 +1,16 @@
 build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
+
 build --crosstool_top=@nixpkgs_config_cc//:toolchain
 # Using toolchain resolution can lead to spurious dependencies on
 # `@local_config_cc//:builtin_include_directory_paths`. This needs to be
 # resolved before `--incompatible_enable_cc_toolchain_resolution` can be
 # recommended for `nixpkgs_cc_configure_hermetic`.
 # build --incompatible_enable_cc_toolchain_resolution
+
+build --javabase=@nixpkgs_java_runtime//:runtime
+build --host_javabase=@nixpkgs_java_runtime//:runtime
+build --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 
 # CI Configuration
 # ----------------

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Links:
 * [nixpkgs_package](#nixpkgs_package)
 * [nixpkgs_cc_configure](#nixpkgs_cc_configure)
 * [nixpkgs_cc_configure_deprecated](#nixpkgs_cc_configure_deprecated)
+* [nixpkgs_java_configure](#nixpkgs_java_configure)
 * [nixpkgs_python_configure](#nixpkgs_python_configure)
 * [nixpkgs_sh_posix_configure](#nixpkgs_sh_posix_configure)
 * [nixpkgs_go_configure](#nixpkgs_go_configure)
@@ -558,6 +559,209 @@ default is <code>[]</code>
 <p>
 
 Options to forward to the nix command.
+
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+
+<a id="#nixpkgs_java_configure"></a>
+
+### nixpkgs_java_configure
+
+<pre>
+nixpkgs_java_configure(<a href="#nixpkgs_java_configure-name">name</a>, <a href="#nixpkgs_java_configure-attribute_path">attribute_path</a>, <a href="#nixpkgs_java_configure-java_home_path">java_home_path</a>, <a href="#nixpkgs_java_configure-repository">repository</a>, <a href="#nixpkgs_java_configure-repositories">repositories</a>, <a href="#nixpkgs_java_configure-nix_file">nix_file</a>,
+                       <a href="#nixpkgs_java_configure-nix_file_content">nix_file_content</a>, <a href="#nixpkgs_java_configure-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_java_configure-nixopts">nixopts</a>, <a href="#nixpkgs_java_configure-fail_not_supported">fail_not_supported</a>, <a href="#nixpkgs_java_configure-quiet">quiet</a>)
+</pre>
+
+Define a Java runtime provided by nixpkgs.
+
+Creates a `nixpkgs_package` for a `java_runtime` instance.
+Bazel can use this instance to run JVM binaries and tests, refer to the
+[Bazel documentation](https://docs.bazel.build/versions/4.0.0/bazel-and-java.html#configuring-the-jdk) for details.
+
+#### Example
+
+Add the following to your `WORKSPACE` file to import a JDK from nixpkgs:
+```bzl
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_java_configure")
+nixpkgs_java_configure(
+    attribute_path = "jdk11.home",
+    repository = "@nixpkgs",
+)
+```
+
+Add the following configuration to `.bazelrc` to enable this Java runtime:
+```
+build --javabase=@nixpkgs_java_runtime//:runtime
+build --host_javabase=@nixpkgs_java_runtime//:runtime
+# Adjust this to match the Java version provided by this runtime.
+# See `bazel query 'kind(java_toolchain, @bazel_tools//tools/jdk:all)'` for available options.
+build --java_toolchain=@bazel_tools//tools/jdk:toolchain_java11
+build --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java11
+```
+
+
+#### Parameters
+
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+<tr id="nixpkgs_java_configure-name">
+<td><code>name</code></td>
+<td>
+
+optional.
+default is <code>"nixpkgs_java_runtime"</code>
+
+<p>
+
+The name-prefix for the created external repositories.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_java_configure-attribute_path">
+<td><code>attribute_path</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+string, The nixpkgs attribute path for `jdk.home`.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_java_configure-java_home_path">
+<td><code>java_home_path</code></td>
+<td>
+
+optional.
+default is <code>""</code>
+
+<p>
+
+optional, string, The path to `JAVA_HOME` within the package.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_java_configure-repository">
+<td><code>repository</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+See [`nixpkgs_package`](#nixpkgs_package-repository).
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_java_configure-repositories">
+<td><code>repositories</code></td>
+<td>
+
+optional.
+default is <code>{}</code>
+
+<p>
+
+See [`nixpkgs_package`](#nixpkgs_package-repositories).
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_java_configure-nix_file">
+<td><code>nix_file</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+optional, Label, Obtain the runtime from the Nix expression defined in this file. Specify only one of `nix_file` or `nix_file_content`.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_java_configure-nix_file_content">
+<td><code>nix_file_content</code></td>
+<td>
+
+optional.
+default is <code>""</code>
+
+<p>
+
+optional, string, Obtain the runtime from the given Nix expression. Specify only one of `nix_file` or `nix_file_content`.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_java_configure-nix_file_deps">
+<td><code>nix_file_deps</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+See [`nixpkgs_package`](#nixpkgs_package-nix_file_deps).
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_java_configure-nixopts">
+<td><code>nixopts</code></td>
+<td>
+
+optional.
+default is <code>[]</code>
+
+<p>
+
+See [`nixpkgs_package`](#nixpkgs_package-nixopts).
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_java_configure-fail_not_supported">
+<td><code>fail_not_supported</code></td>
+<td>
+
+optional.
+default is <code>True</code>
+
+<p>
+
+See [`nixpkgs_package`](#nixpkgs_package-fail_not_supported).
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_java_configure-quiet">
+<td><code>quiet</code></td>
+<td>
+
+optional.
+default is <code>False</code>
+
+<p>
+
+See [`nixpkgs_package`](#nixpkgs_package-quiet).
 
 </p>
 </td>

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,6 +8,7 @@ rules_nixpkgs_dependencies()
 load(
     "//nixpkgs:nixpkgs.bzl",
     "nixpkgs_cc_configure",
+    "nixpkgs_java_configure",
     "nixpkgs_git_repository",
     "nixpkgs_local_repository",
     "nixpkgs_package",
@@ -182,6 +183,15 @@ nixpkgs_cc_configure(
     # Use a different name to be able to distinguish this toolchain from the
     # builtin one in the tests.
     name = "nixpkgs_config_cc",
+    repository = "@remote_nixpkgs",
+)
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies")
+
+rules_java_dependencies()
+
+nixpkgs_java_configure(
+    attribute_path = "jdk8.home",
     repository = "@remote_nixpkgs",
 )
 

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -10,6 +10,7 @@ stardoc(
         "nixpkgs_package",
         "nixpkgs_cc_configure",
         "nixpkgs_cc_configure_deprecated",
+        "nixpkgs_java_configure",
         "nixpkgs_python_configure",
         "nixpkgs_sh_posix_configure",
     ],

--- a/docs/README.md.tpl
+++ b/docs/README.md.tpl
@@ -28,6 +28,7 @@ Links:
 * [nixpkgs_package](#nixpkgs_package)
 * [nixpkgs_cc_configure](#nixpkgs_cc_configure)
 * [nixpkgs_cc_configure_deprecated](#nixpkgs_cc_configure_deprecated)
+* [nixpkgs_java_configure](#nixpkgs_java_configure)
 * [nixpkgs_python_configure](#nixpkgs_python_configure)
 * [nixpkgs_sh_posix_configure](#nixpkgs_sh_posix_configure)
 * [nixpkgs_go_configure](#nixpkgs_go_configure)

--- a/nixpkgs/repositories.bzl
+++ b/nixpkgs/repositories.bzl
@@ -21,3 +21,9 @@ def rules_nixpkgs_dependencies():
         ],
         sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
     )
+    maybe(
+        http_archive,
+        "rules_java",
+        url = "https://github.com/bazelbuild/rules_java/releases/download/4.0.0/rules_java-4.0.0.tar.gz",
+        sha256 = "34b41ec683e67253043ab1a3d1e8b7c61e4e8edefbcad485381328c934d072fe",
+    )

--- a/shell.nix
+++ b/shell.nix
@@ -9,6 +9,5 @@ mkShell {
     gcc
     nix
     git
-    jdk11
   ];
 }

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,7 +1,9 @@
 package(default_testonly = 1)
 
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@rules_java//java:defs.bzl", "java_binary", "java_test")
 load(":cc-test.bzl", "cc_toolchain_test")
+load(":java-test.bzl", "java_runtime_test")
 load(":location_expansion_unit_test.bzl", "expand_location_unit_test_suite")
 
 expand_location_unit_test_suite()
@@ -90,6 +92,18 @@ cc_binary(
 # Test that nixpkgs_cc_configure is selected.
 cc_toolchain_test(
     name = "cc-toolchain",
+)
+
+# Test nixpkgs_java_configure() by building some Java code.
+java_test(
+    name = "java-test",
+    test_class = "JavaTest",
+    srcs = ["JavaTest.java"],
+)
+
+# Test that nixpkgs_java_runtime is selected.
+java_runtime_test(
+    name = "java-runtime",
 )
 
 # Test nixpkgs_python_configure() by running some Python code.

--- a/tests/JavaTest.java
+++ b/tests/JavaTest.java
@@ -1,0 +1,14 @@
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class JavaTest {
+  @Test
+  public void testHello() throws Exception {
+    System.out.println("Hello Java!");
+  }
+}

--- a/tests/java-test.bzl
+++ b/tests/java-test.bzl
@@ -1,0 +1,45 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+def _java_runtime_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    nixpkgs_java_runtime = ctx.attr._nixpkgs_java_runtime[platform_common.ToolchainInfo]
+
+    java_runtime = ctx.attr._java_runtime[java_common.JavaRuntimeInfo]
+    asserts.equals(
+        env,
+        expected = nixpkgs_java_runtime.java_home,
+        actual = java_runtime.java_home,
+        msg = "Expected selected Java runtime JAVA_HOME to equal Nix provided JAVA_HOME.",
+    )
+    asserts.equals(
+        env,
+        expected = nixpkgs_java_runtime.java_executable_exec_path,
+        actual = java_runtime.java_executable_exec_path,
+        msg = "Expected selected Java runtime java binary to equal Nix provided java.",
+    )
+
+    host_java_runtime = ctx.attr._host_java_runtime[java_common.JavaRuntimeInfo]
+    asserts.equals(
+        env,
+        expected = nixpkgs_java_runtime.java_home,
+        actual = host_java_runtime.java_home,
+        msg = "Expected selected host Java runtime JAVA_HOME to equal Nix provided JAVA_HOME.",
+    )
+    asserts.equals(
+        env,
+        expected = nixpkgs_java_runtime.java_executable_exec_path,
+        actual = host_java_runtime.java_executable_exec_path,
+        msg = "Expected selected host Java runtime java binary to equal Nix provided java.",
+    )
+
+    return unittest.end(env)
+
+java_runtime_test = unittest.make(
+    _java_runtime_test_impl,
+    attrs = {
+        "_nixpkgs_java_runtime": attr.label(default = Label("@nixpkgs_java_runtime//:runtime")),
+        "_java_runtime": attr.label(default = Label("@bazel_tools//tools/jdk:current_java_runtime")),
+        "_host_java_runtime": attr.label(default = Label("@bazel_tools//tools/jdk:current_host_java_runtime")),
+    },
+)


### PR DESCRIPTION
Add `nixpkgs_java_configure` which imports a Java runtime provided by nixpkgs.
The Java runtime is used by Bazel to execute Bazel built JVM targets, e.g. `java_binary`. It is distinct from the Java toolchain which is used to build JVM targets. Refer to the [Bazel documentation][bazel-java] for details.
This is based on the implementation [in the `daml` repository](https://github.com/digital-asset/daml/pull/11411) (cc @cocreature).

Note, Bazel 4 does not yet support platform based toolchain resolution for the Java toolchain. This feature will only be supported starting from [Bazel 5](https://docs.bazel.build/versions/main/bazel-and-java.html#configuring-the-java-toolchains). Meaning, `nixpkgs_java_configure` is different from e.g. `nixpkgs_cc_configure` in that there is no toolchain registration involved and the user instead has to explicitly pick a particular Java runtime using the `--(host_)javabase` flags.

Adds tests for the nixpkgs provided Java runtime:
- Build and run a `java_test`.
- Test that the selected Java runtime is indeed the Nix provided one.

[bazel-java]: https://docs.bazel.build/versions/4.0.0/bazel-and-java.html#configuring-the-jdk