### PR TITLE
Support registering a Java toolchain for Bazel 5

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -61,7 +61,7 @@ jobs:
 
           cd examples/toolchains
           with_nix=( $(ls) )
-          without_nix=( cc go rust )
+          without_nix=( cc go java rust )
 
           if [ "${{ runner.os }}" == "macOS" ]; then
             # Rust - https://github.com/tweag/rules_nixpkgs/issues/187

--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ Options to forward to the nix command.
 <pre>
 nixpkgs_java_configure(<a href="#nixpkgs_java_configure-name">name</a>, <a href="#nixpkgs_java_configure-attribute_path">attribute_path</a>, <a href="#nixpkgs_java_configure-java_home_path">java_home_path</a>, <a href="#nixpkgs_java_configure-repository">repository</a>, <a href="#nixpkgs_java_configure-repositories">repositories</a>, <a href="#nixpkgs_java_configure-nix_file">nix_file</a>,
                        <a href="#nixpkgs_java_configure-nix_file_content">nix_file_content</a>, <a href="#nixpkgs_java_configure-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_java_configure-nixopts">nixopts</a>, <a href="#nixpkgs_java_configure-fail_not_supported">fail_not_supported</a>, <a href="#nixpkgs_java_configure-quiet">quiet</a>, <a href="#nixpkgs_java_configure-toolchain">toolchain</a>,
-                       <a href="#nixpkgs_java_configure-toolchain_name">toolchain_name</a>, <a href="#nixpkgs_java_configure-toolchain_version">toolchain_version</a>)
+                       <a href="#nixpkgs_java_configure-toolchain_name">toolchain_name</a>, <a href="#nixpkgs_java_configure-toolchain_version">toolchain_version</a>, <a href="#nixpkgs_java_configure-exec_constraints">exec_constraints</a>, <a href="#nixpkgs_java_configure-target_constraints">target_constraints</a>)
 </pre>
 
 Define a Java runtime provided by nixpkgs.
@@ -843,6 +843,34 @@ default is <code>None</code>
 <p>
 
 The version of the toolchain that can be used in --java_runtime_version.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_java_configure-exec_constraints">
+<td><code>exec_constraints</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+Constraints for the execution platform.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_java_configure-target_constraints">
+<td><code>target_constraints</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+Constraints for the target platform.
 
 </p>
 </td>

--- a/README.md
+++ b/README.md
@@ -587,16 +587,20 @@ Options to forward to the nix command.
 
 <pre>
 nixpkgs_java_configure(<a href="#nixpkgs_java_configure-name">name</a>, <a href="#nixpkgs_java_configure-attribute_path">attribute_path</a>, <a href="#nixpkgs_java_configure-java_home_path">java_home_path</a>, <a href="#nixpkgs_java_configure-repository">repository</a>, <a href="#nixpkgs_java_configure-repositories">repositories</a>, <a href="#nixpkgs_java_configure-nix_file">nix_file</a>,
-                       <a href="#nixpkgs_java_configure-nix_file_content">nix_file_content</a>, <a href="#nixpkgs_java_configure-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_java_configure-nixopts">nixopts</a>, <a href="#nixpkgs_java_configure-fail_not_supported">fail_not_supported</a>, <a href="#nixpkgs_java_configure-quiet">quiet</a>)
+                       <a href="#nixpkgs_java_configure-nix_file_content">nix_file_content</a>, <a href="#nixpkgs_java_configure-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_java_configure-nixopts">nixopts</a>, <a href="#nixpkgs_java_configure-fail_not_supported">fail_not_supported</a>, <a href="#nixpkgs_java_configure-quiet">quiet</a>, <a href="#nixpkgs_java_configure-toolchain">toolchain</a>,
+                       <a href="#nixpkgs_java_configure-toolchain_name">toolchain_name</a>, <a href="#nixpkgs_java_configure-toolchain_version">toolchain_version</a>)
 </pre>
 
 Define a Java runtime provided by nixpkgs.
 
-Creates a `nixpkgs_package` for a `java_runtime` instance.
+Creates a `nixpkgs_package` for a `java_runtime` instance. Optionally,
+you can also create & register a Java toolchain. This only works with Bazel >= 5.0
 Bazel can use this instance to run JVM binaries and tests, refer to the
 [Bazel documentation](https://docs.bazel.build/versions/4.0.0/bazel-and-java.html#configuring-the-jdk) for details.
 
 #### Example
+
+##### Bazel 4
 
 Add the following to your `WORKSPACE` file to import a JDK from nixpkgs:
 ```bzl
@@ -615,6 +619,27 @@ build --host_javabase=@nixpkgs_java_runtime//:runtime
 # See `bazel query 'kind(java_toolchain, @bazel_tools//tools/jdk:all)'` for available options.
 build --java_toolchain=@bazel_tools//tools/jdk:toolchain_java11
 build --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java11
+```
+
+##### Bazel 5
+
+Add the following to your `WORKSPACE` file to import a JDK from nixpkgs:
+```bzl
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_java_configure")
+nixpkgs_java_configure(
+    attribute_path = "jdk11.home",
+    repository = "@nixpkgs",
+    toolchain = True,
+    toolchain_name = "nixpkgs_java",
+    toolchain_version = "11",
+)
+```
+
+Add the following configuration to `.bazelrc` to enable this Java runtime:
+```
+build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
+build --java_runtime_version=nixpkgs_java
+build --tool_java_runtime_version=nixpkgs_java
 ```
 
 
@@ -776,6 +801,48 @@ default is <code>False</code>
 <p>
 
 See [`nixpkgs_package`](#nixpkgs_package-quiet).
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_java_configure-toolchain">
+<td><code>toolchain</code></td>
+<td>
+
+optional.
+default is <code>False</code>
+
+<p>
+
+Create & register a Bazel toolchain based on the Java runtime.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_java_configure-toolchain_name">
+<td><code>toolchain_name</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+The name of the toolchain that can be used in --java_runtime_version.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_java_configure-toolchain_version">
+<td><code>toolchain_version</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+The version of the toolchain that can be used in --java_runtime_version.
 
 </p>
 </td>

--- a/examples/toolchains/java/.bazelrc
+++ b/examples/toolchains/java/.bazelrc
@@ -1,3 +1,3 @@
 build:nix --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
-build:nix --java_runtime_version=nixpkgs_java
-build:nix --tool_java_runtime_version=nixpkgs_java
+build:nix --java_runtime_version=nixpkgs_java_11
+build:nix --tool_java_runtime_version=nixpkgs_java_11

--- a/examples/toolchains/java/.bazelrc
+++ b/examples/toolchains/java/.bazelrc
@@ -1,3 +1,3 @@
 build:nix --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
-build:nix --java_runtime_version=nixpkgs_java_11
-build:nix --tool_java_runtime_version=nixpkgs_java_11
+build:nix --java_runtime_version=nixpkgs_java
+build:nix --tool_java_runtime_version=nixpkgs_java

--- a/examples/toolchains/java/.bazelrc
+++ b/examples/toolchains/java/.bazelrc
@@ -1,0 +1,1 @@
+build:nix --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host

--- a/examples/toolchains/java/.bazelrc
+++ b/examples/toolchains/java/.bazelrc
@@ -1,1 +1,3 @@
 build:nix --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
+build:nix --java_runtime_version=nixpkgs_java_11
+build:nix --tool_java_runtime_version=nixpkgs_java_11

--- a/examples/toolchains/java/.bazelrc
+++ b/examples/toolchains/java/.bazelrc
@@ -1,3 +1,6 @@
 build:nix --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
 build:nix --java_runtime_version=nixpkgs_java_11
 build:nix --tool_java_runtime_version=nixpkgs_java_11
+
+build --java_language_version=11
+build --tool_java_language_version=11

--- a/examples/toolchains/java/.bazelrc
+++ b/examples/toolchains/java/.bazelrc
@@ -1,6 +1,5 @@
 build:nix --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
 build:nix --java_runtime_version=nixpkgs_java_11
 build:nix --tool_java_runtime_version=nixpkgs_java_11
-
-build --java_language_version=11
-build --tool_java_language_version=11
+build:nix --java_language_version=11
+build:nix --tool_java_language_version=11

--- a/examples/toolchains/java/BUILD
+++ b/examples/toolchains/java/BUILD
@@ -1,0 +1,5 @@
+java_binary(
+    name = "hello",
+    srcs = ["Main.java"],
+    main_class = "Main",
+)

--- a/examples/toolchains/java/Main.java
+++ b/examples/toolchains/java/Main.java
@@ -1,0 +1,5 @@
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello world");
+    }
+}

--- a/examples/toolchains/java/README.md
+++ b/examples/toolchains/java/README.md
@@ -3,11 +3,16 @@ Java Toolchain Example
 
 This is an example Java project with modules that uses the builtin Bazel Java rules.
 
-This example uses the Nix package manager to provide the Java toolchain, and as such only works with Nix installed.
+If the Nix package manager is present in the build environment, this example will use Nix to provide the Java runtime. Otherwise, it will use the default runtime and not rely on Nix at all.
 
 # Usage
 
 To run the example with Nix, issue the following command:
 ```
 nix-shell --command 'bazel run --config=nix :hello'
+```
+
+To run the example without Nix, make sure you have Bazel installed, and issue the following command:
+```
+bazel run :hello
 ```

--- a/examples/toolchains/java/README.md
+++ b/examples/toolchains/java/README.md
@@ -1,0 +1,13 @@
+Java Toolchain Example
+========================
+
+This is an example Java project with modules that uses the builtin Bazel Java rules.
+
+This example uses the Nix package manager to provide the Java toolchain, and as such only works with Nix installed.
+
+# Usage
+
+To run the example with Nix, issue the following command:
+```
+nix-shell --command 'bazel run --config=nix :hello'
+```

--- a/examples/toolchains/java/WORKSPACE
+++ b/examples/toolchains/java/WORKSPACE
@@ -5,6 +5,20 @@ local_repository(
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_java",
+    url = "https://github.com/bazelbuild/rules_java/archive/refs/tags/5.0.0.tar.gz",
+    sha256 = "ddc9e11f4836265fea905d2845ac1d04ebad12a255f791ef7fd648d1d2215a5b",
+    strip_prefix = "rules_java-5.0.0",
+)
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+rules_java_toolchains()
+
 load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
 
 rules_nixpkgs_dependencies()

--- a/examples/toolchains/java/WORKSPACE
+++ b/examples/toolchains/java/WORKSPACE
@@ -8,9 +8,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_java",
-    url = "https://github.com/bazelbuild/rules_java/archive/refs/tags/5.0.0.tar.gz",
     sha256 = "ddc9e11f4836265fea905d2845ac1d04ebad12a255f791ef7fd648d1d2215a5b",
     strip_prefix = "rules_java-5.0.0",
+    url = "https://github.com/bazelbuild/rules_java/archive/refs/tags/5.0.0.tar.gz",
 )
 
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
@@ -34,8 +34,8 @@ nixpkgs_git_repository(
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_java_configure")
 
 nixpkgs_java_configure(
-    repository = "@nixpkgs",
     attribute_path = "jdk11.home",
+    repository = "@nixpkgs",
     toolchain = True,
     toolchain_name = "nixpkgs_java",
     toolchain_version = "11",

--- a/examples/toolchains/java/WORKSPACE
+++ b/examples/toolchains/java/WORKSPACE
@@ -23,4 +23,6 @@ nixpkgs_java_configure(
     repository = "@nixpkgs",
     attribute_path = "jdk11.home",
     toolchain = True,
+    toolchain_name = "nixpkgs_java",
+    toolchain_version = "11",
 )

--- a/examples/toolchains/java/WORKSPACE
+++ b/examples/toolchains/java/WORKSPACE
@@ -17,8 +17,6 @@ load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_jav
 
 rules_java_dependencies()
 
-rules_java_toolchains()
-
 load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
 
 rules_nixpkgs_dependencies()
@@ -40,3 +38,5 @@ nixpkgs_java_configure(
     toolchain_name = "nixpkgs_java",
     toolchain_version = "11",
 )
+
+rules_java_toolchains()

--- a/examples/toolchains/java/WORKSPACE
+++ b/examples/toolchains/java/WORKSPACE
@@ -1,0 +1,26 @@
+# Replace with http_archive: https://github.com/tweag/rules_nixpkgs/#setup
+local_repository(
+    name = "io_tweag_rules_nixpkgs",
+    path = "../../../",
+)
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
+
+rules_nixpkgs_dependencies()
+
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository")
+
+nixpkgs_git_repository(
+    name = "nixpkgs",
+    revision = "21.11",
+    sha256 = "c77bb41cf5dd82f4718fa789d49363f512bb6fa6bc25f8d60902fe2d698ed7cc",
+)
+
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_java_configure")
+
+nixpkgs_java_configure(
+    repository = "@nixpkgs",
+    attribute_path = "jdk11.home",
+    toolchain = True,
+)

--- a/examples/toolchains/java/nixpkgs.json
+++ b/examples/toolchains/java/nixpkgs.json
@@ -1,0 +1,8 @@
+{
+  "owner": "NixOS",
+  "repo": "nixpkgs",
+  "branch": "unstable",
+  "rev": "7f9b6e2babf232412682c09e57ed666d8f84ac2d",
+  "sha256": "03nb8sbzgc3c0qdr1jbsn852zi3qp74z4qcy7vrabvvly8rbixp2"
+}
+

--- a/examples/toolchains/java/nixpkgs.nix
+++ b/examples/toolchains/java/nixpkgs.nix
@@ -1,0 +1,10 @@
+let
+  # nixpkgs-unstable as of 2021-02-21
+  spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+  nixpkgs = fetchTarball {
+    url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
+    sha256 = spec.sha256;
+  };
+in
+import nixpkgs
+

--- a/examples/toolchains/java/shell.nix
+++ b/examples/toolchains/java/shell.nix
@@ -1,6 +1,3 @@
-{ pkgs ? import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/7f9b6e2babf232412682c09e57ed666d8f84ac2d.tar.gz";
-  sha256 = "03nb8sbzgc3c0qdr1jbsn852zi3qp74z4qcy7vrabvvly8rbixp2";
-}) { } }:
+{ pkgs ? import ./nixpkgs.nix { } }:
 
 pkgs.mkShell { nativeBuildInputs = [ pkgs.bazel_5 ]; }

--- a/examples/toolchains/java/shell.nix
+++ b/examples/toolchains/java/shell.nix
@@ -1,0 +1,6 @@
+{ pkgs ? import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/7f9b6e2babf232412682c09e57ed666d8f84ac2d.tar.gz";
+  sha256 = "03nb8sbzgc3c0qdr1jbsn852zi3qp74z4qcy7vrabvvly8rbixp2";
+}) { } }:
+
+pkgs.mkShell { nativeBuildInputs = [ pkgs.bazel_5 ]; }

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -934,12 +934,11 @@ def _nixpkgs_java_toolchain_impl(repository_ctx):
         executable = False,
         content = """\
 load("@bazel_tools//tools/jdk:local_java_repository.bzl", "local_java_runtime")
-load("@{runtime}//:java_home.bzl", "java_home")
 local_java_runtime(
    name = "{name}",
    version = "{version}",
    runtime_name = "@{runtime}//:runtime",
-   java_home = java_home,
+   java_home = None,
 )
 """.format(
             runtime = repository_ctx.attr.runtime_repo,

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -980,6 +980,8 @@ def nixpkgs_java_configure(
 
     #### Example
 
+    ##### Bazel 4
+
     Add the following to your `WORKSPACE` file to import a JDK from nixpkgs:
     ```bzl
     load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_java_configure")
@@ -997,6 +999,27 @@ def nixpkgs_java_configure(
     # See `bazel query 'kind(java_toolchain, @bazel_tools//tools/jdk:all)'` for available options.
     build --java_toolchain=@bazel_tools//tools/jdk:toolchain_java11
     build --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java11
+    ```
+
+    ##### Bazel 5
+
+    Add the following to your `WORKSPACE` file to import a JDK from nixpkgs:
+    ```bzl
+    load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_java_configure")
+    nixpkgs_java_configure(
+        attribute_path = "jdk11.home",
+        repository = "@nixpkgs",
+        toolchain = True,
+        toolchain_name = "nixpkgs_java",
+        toolchain_version = "11",
+    )
+    ```
+
+    Add the following configuration to `.bazelrc` to enable this Java runtime:
+    ```
+    build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
+    build --java_runtime_version=nixpkgs_java
+    build --tool_java_runtime_version=nixpkgs_java
     ```
 
     Args:

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -922,9 +922,6 @@ pkgs.runCommand "bazel-nixpkgs-java-runtime"
         visibility = ["//visibility:public"],
     )
     EOF
-    cat >$out/java_home.bzl <<EOF
-    java_home = r"${javaHomePath}"
-    EOF
   ''
 """
 

--- a/nixpkgs/toolchains/java/default_java_toolchain.bzl
+++ b/nixpkgs/toolchains/java/default_java_toolchain.bzl
@@ -1,0 +1,295 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bazel rules for creating Java toolchains."""
+
+JDK8_JVM_OPTS = [
+    "-Xbootclasspath/p:$(location @remote_java_tools//:javac_jar)",
+]
+
+# JVM options, without patching java.compiler and jdk.compiler modules.
+BASE_JDK9_JVM_OPTS = [
+    # Allow JavaBuilder to access internal javac APIs.
+    "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.resources=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+
+    # quiet warnings from com.google.protobuf.UnsafeUtil,
+    # see: https://github.com/google/protobuf/issues/3781
+    # and: https://github.com/bazelbuild/bazel/issues/5599
+    "--add-opens=java.base/java.nio=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+]
+
+JDK9_JVM_OPTS = BASE_JDK9_JVM_OPTS + [
+    # override the javac in the JDK.
+    "--patch-module=java.compiler=$(location @remote_java_tools//:java_compiler_jar)",
+    "--patch-module=jdk.compiler=$(location @remote_java_tools//:jdk_compiler_jar)",
+]
+
+DEFAULT_JAVACOPTS = [
+    "-XDskipDuplicateBridges=true",
+    "-XDcompilePolicy=simple",
+    "-g",
+    "-parameters",
+    # https://github.com/bazelbuild/java_tools/issues/51#issuecomment-927940699
+    "-XepOpt:ReturnValueIgnored:ObjectMethods=false",
+]
+
+# java_toolchain parameters without specifying javac, java.compiler,
+# jdk.compiler module, and jvm_opts
+_BASE_TOOLCHAIN_CONFIGURATION = dict(
+    forcibly_disable_header_compilation = False,
+    genclass = ["@remote_java_tools//:GenClass"],
+    header_compiler = ["@remote_java_tools//:TurbineDirect"],
+    header_compiler_direct = ["@remote_java_tools//:TurbineDirect"],
+    ijar = ["@bazel_tools//tools/jdk:ijar"],
+    javabuilder = ["@remote_java_tools//:JavaBuilder"],
+    javac_supports_workers = True,
+    jacocorunner = "@remote_java_tools//:jacoco_coverage_runner_filegroup",
+    jvm_opts = BASE_JDK9_JVM_OPTS,
+    misc = DEFAULT_JAVACOPTS,
+    singlejar = ["@bazel_tools//tools/jdk:singlejar"],
+    # Code to enumerate target JVM boot classpath uses host JVM. Because
+    # java_runtime-s are involved, its implementation is in @bazel_tools.
+    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],
+    source_version = "8",
+    target_version = "8",
+    reduced_classpath_incompatible_processors = [
+        "dagger.hilt.processor.internal.root.RootProcessor",  # see b/21307381
+    ],
+)
+
+JVM8_TOOLCHAIN_CONFIGURATION = dict(
+    tools = ["@remote_java_tools//:javac_jar"],
+    jvm_opts = ["-Xbootclasspath/p:$(location @remote_java_tools//:javac_jar)"],
+    java_runtime = "@bazel_tools//tools/jdk:jdk_8",
+)
+
+DEFAULT_TOOLCHAIN_CONFIGURATION = dict(
+    jvm_opts = [
+        # Compact strings make JavaBuilder slightly slower.
+        "-XX:-CompactStrings",
+    ] + JDK9_JVM_OPTS,
+    turbine_jvm_opts = [
+        # Turbine is not a worker and parallel GC is faster for short-lived programs.
+        "-XX:+UseParallelOldGC",
+    ],
+    tools = [
+        "@remote_java_tools//:java_compiler_jar",
+        "@remote_java_tools//:jdk_compiler_jar",
+    ],
+    java_runtime = "@bazel_tools//tools/jdk:remote_jdk11",
+)
+
+# The 'vanilla' toolchain is an unsupported alternative to the default.
+#
+# It does not provide any of the following features:
+#   * Error Prone
+#   * Strict Java Deps
+#   * Reduced Classpath Optimization
+#
+# It uses the version of internal javac from the `--host_javabase` JDK instead
+# of providing a javac. Internal javac may not be source- or bug-compatible with
+# the javac that is provided with other toolchains.
+#
+# However it does allow using a wider range of `--host_javabase`s, including
+# versions newer than the current JDK.
+VANILLA_TOOLCHAIN_CONFIGURATION = dict(
+    javabuilder = ["@remote_java_tools//:VanillaJavaBuilder"],
+    jvm_opts = [],
+)
+
+# The new toolchain is using all the pre-built tools, including
+# singlejar and ijar, even on remote execution. This toolchain
+# should be used only when host and execution platform are the
+# same, otherwise the binaries will not work on the execution
+# platform.
+PREBUILT_TOOLCHAIN_CONFIGURATION = dict(
+    jvm_opts = [
+        # Compact strings make JavaBuilder slightly slower.
+        "-XX:-CompactStrings",
+    ] + JDK9_JVM_OPTS,
+    turbine_jvm_opts = [
+        # Turbine is not a worker and parallel GC is faster for short-lived programs.
+        "-XX:+UseParallelOldGC",
+    ],
+    tools = [
+        "@remote_java_tools//:java_compiler_jar",
+        "@remote_java_tools//:jdk_compiler_jar",
+    ],
+    ijar = ["@bazel_tools//tools/jdk:ijar_prebuilt_binary"],
+    singlejar = ["@bazel_tools//tools/jdk:prebuilt_singlejar"],
+    java_runtime = "@bazel_tools//tools/jdk:remote_jdk11",
+)
+
+# The new toolchain is using all the tools from sources.
+NONPREBUILT_TOOLCHAIN_CONFIGURATION = dict(
+    jvm_opts = [
+        # Compact strings make JavaBuilder slightly slower.
+        "-XX:-CompactStrings",
+    ] + JDK9_JVM_OPTS,
+    turbine_jvm_opts = [
+        # Turbine is not a worker and parallel GC is faster for short-lived programs.
+        "-XX:+UseParallelOldGC",
+    ],
+    tools = [
+        "@remote_java_tools//:java_compiler_jar",
+        "@remote_java_tools//:jdk_compiler_jar",
+    ],
+    ijar = ["@remote_java_tools//:ijar_cc_binary"],
+    singlejar = ["@remote_java_tools//:singlejar_cc_bin"],
+    java_runtime = "@bazel_tools//tools/jdk:remote_jdk11",
+)
+
+def default_java_toolchain(name, configuration = DEFAULT_TOOLCHAIN_CONFIGURATION, toolchain_definition = True, exec_compatible_with = [], target_compatible_with = [], **kwargs):
+    """Defines a remote java_toolchain with appropriate defaults for Bazel."""
+
+    toolchain_args = dict(_BASE_TOOLCHAIN_CONFIGURATION)
+    toolchain_args.update(configuration)
+    toolchain_args.update(kwargs)
+    native.java_toolchain(
+        name = name,
+        **toolchain_args
+    )
+    if toolchain_definition:
+        native.config_setting(
+            name = name + "_version_setting",
+            values = {"java_language_version": toolchain_args["source_version"]},
+            visibility = ["//visibility:private"],
+        )
+        native.toolchain(
+            name = name + "_definition",
+            toolchain_type = "@bazel_tools//tools/jdk:toolchain_type",
+            target_settings = [name + "_version_setting"],
+            toolchain = name,
+            exec_compatible_with = exec_compatible_with,
+            target_compatible_with = target_compatible_with,
+        )
+
+def java_runtime_files(name, srcs):
+    """Copies the given sources out of the current Java runtime."""
+
+    native.filegroup(
+        name = name,
+        srcs = srcs,
+    )
+    for src in srcs:
+        native.genrule(
+            name = "gen_%s" % src,
+            srcs = ["@bazel_tools//tools/jdk:current_java_runtime"],
+            toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+            cmd = "cp $(JAVABASE)/%s $@" % src,
+            outs = [src],
+        )
+
+def _bootclasspath_impl(ctx):
+    host_javabase = ctx.attr.host_javabase[java_common.JavaRuntimeInfo]
+
+    # explicitly list output files instead of using TreeArtifact to work around
+    # https://github.com/bazelbuild/bazel/issues/6203
+    classes = [
+        "DumpPlatformClassPath.class",
+    ]
+
+    class_outputs = [
+        ctx.actions.declare_file("%s_classes/%s" % (ctx.label.name, clazz))
+        for clazz in classes
+    ]
+
+    args = ctx.actions.args()
+    args.add("-source")
+    args.add("8")
+    args.add("-target")
+    args.add("8")
+    args.add("-Xlint:-options")
+    args.add("-cp")
+    args.add("%s/lib/tools.jar" % host_javabase.java_home)
+    args.add("-d")
+    args.add(class_outputs[0].dirname)
+    args.add(ctx.file.src)
+
+    ctx.actions.run(
+        executable = "%s/bin/javac" % host_javabase.java_home,
+        mnemonic = "JavaToolchainCompileClasses",
+        inputs = [ctx.file.src] + ctx.files.host_javabase,
+        outputs = class_outputs,
+        arguments = [args],
+    )
+
+    bootclasspath = ctx.outputs.output_jar
+
+    inputs = class_outputs + ctx.files.host_javabase
+
+    args = ctx.actions.args()
+    args.add("-XX:+IgnoreUnrecognizedVMOptions")
+    args.add("--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED")
+    args.add("--add-exports=jdk.compiler/com.sun.tools.javac.platform=ALL-UNNAMED")
+    args.add("--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED")
+    args.add_joined(
+        "-cp",
+        [class_outputs[0].dirname, "%s/lib/tools.jar" % host_javabase.java_home],
+        join_with = ctx.configuration.host_path_separator,
+    )
+    args.add("DumpPlatformClassPath")
+    args.add(bootclasspath)
+
+    if ctx.attr.target_javabase:
+        inputs.extend(ctx.files.target_javabase)
+        args.add(ctx.attr.target_javabase[java_common.JavaRuntimeInfo].java_home)
+
+    ctx.actions.run(
+        executable = str(host_javabase.java_executable_exec_path),
+        mnemonic = "JavaToolchainCompileBootClasspath",
+        inputs = inputs,
+        outputs = [bootclasspath],
+        arguments = [args],
+    )
+    return [
+        DefaultInfo(files = depset([bootclasspath])),
+        OutputGroupInfo(jar = [bootclasspath]),
+    ]
+
+_bootclasspath = rule(
+    implementation = _bootclasspath_impl,
+    attrs = {
+        "host_javabase": attr.label(
+            cfg = "host",
+            providers = [java_common.JavaRuntimeInfo],
+        ),
+        "src": attr.label(
+            cfg = "host",
+            allow_single_file = True,
+        ),
+        "target_javabase": attr.label(
+            providers = [java_common.JavaRuntimeInfo],
+        ),
+        "output_jar": attr.output(mandatory = True),
+    },
+)
+
+def bootclasspath(name, **kwargs):
+    _bootclasspath(
+        name = name,
+        output_jar = name + ".jar",
+        **kwargs
+    )

--- a/nixpkgs/toolchains/java/local_java_repository.bzl
+++ b/nixpkgs/toolchains/java/local_java_repository.bzl
@@ -1,0 +1,238 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rules for importing and registering a local JDK."""
+
+load(":toolchains/java/default_java_toolchain.bzl", "JVM8_TOOLCHAIN_CONFIGURATION", "default_java_toolchain")
+
+def _detect_java_version(repository_ctx, java_bin):
+    properties_out = repository_ctx.execute([java_bin, "-XshowSettings:properties"]).stderr
+    # This returns an indented list of properties separated with newlines:
+    # "  java.vendor.url.bug = ... \n"
+    # "  java.version = 11.0.8\n"
+    # "  java.version.date = 2020-11-05\"
+
+    strip_properties = [property.strip() for property in properties_out.splitlines()]
+    version_property = [property for property in strip_properties if property.startswith("java.version = ")]
+    if len(version_property) != 1:
+        return None
+
+    version_value = version_property[0][len("java.version = "):]
+    parts = version_value.split(".")
+    major = parts[0]
+    if len(parts) == 1:
+        return major
+    elif major == "1":  # handles versions below 1.8
+        minor = parts[1]
+        return minor
+    return major
+
+def local_java_runtime(name, java_home, version, runtime_name = None, visibility = ["//visibility:public"], exec_compatible_with = [], target_compatible_with = []):
+    """Defines a java_runtime target together with Java runtime and compile toolchain definitions.
+
+    Java runtime toolchain is constrained by flag --java_runtime_version having
+    value set to either name or version argument.
+
+    Java compile toolchains are created for --java_language_version flags values
+    between 8 and version (inclusive). Java compile toolchains use the same
+    (local) JDK for compilation. This requires a different configuration for JDK8
+    than the newer versions.
+
+    Args:
+      name: name of the target.
+      java_home: Path to the JDK.
+      version: Version of the JDK.
+      runtime_name: name of java_runtime target if it already exists.
+      visibility: Visibility that will be applied to the java runtime target
+    """
+    if runtime_name == None:
+        runtime_name = name
+        native.java_runtime(
+            name = runtime_name,
+            java_home = java_home,
+            visibility = visibility,
+        )
+
+    native.config_setting(
+        name = name + "_name_setting",
+        values = {"java_runtime_version": name},
+        visibility = ["//visibility:private"],
+    )
+    native.config_setting(
+        name = name + "_version_setting",
+        values = {"java_runtime_version": version},
+        visibility = ["//visibility:private"],
+    )
+    native.config_setting(
+        name = name + "_name_version_setting",
+        values = {"java_runtime_version": name + "_" + version},
+        visibility = ["//visibility:private"],
+    )
+    native.alias(
+        name = name + "_settings_alias",
+        actual = select({
+            name + "_name_setting": name + "_name_setting",
+            name + "_version_setting": name + "_version_setting",
+            "//conditions:default": name + "_name_version_setting",
+        }),
+        visibility = ["//visibility:private"],
+    )
+    native.toolchain(
+        name = "runtime_toolchain_definition",
+        target_settings = [":%s_settings_alias" % name],
+        toolchain_type = "@bazel_tools//tools/jdk:runtime_toolchain_type",
+        toolchain = runtime_name,
+        exec_compatible_with = exec_compatible_with,
+        target_compatible_with = target_compatible_with,
+    )
+
+    if version == "8":
+        default_java_toolchain(
+            name = name + "_toolchain_java8",
+            configuration = JVM8_TOOLCHAIN_CONFIGURATION,
+            source_version = version,
+            target_version = version,
+            java_runtime = runtime_name,
+            exec_compatible_with = exec_compatible_with,
+            target_compatible_with = target_compatible_with,
+        )
+    elif type(version) == type("") and version.isdigit() and int(version) > 8:
+        for version in range(8, int(version) + 1):
+            default_java_toolchain(
+                name = name + "_toolchain_java" + str(version),
+                source_version = str(version),
+                target_version = str(version),
+                java_runtime = runtime_name,
+                exec_compatible_with = exec_compatible_with,
+                target_compatible_with = target_compatible_with,
+            )
+
+    # else version is not recognized and no compilation toolchains are predefined
+
+def _local_java_repository_impl(repository_ctx):
+    """Repository rule local_java_repository implementation.
+
+    Args:
+      repository_ctx: repository context
+    """
+    java_home = repository_ctx.attr.java_home
+    java_home_path = repository_ctx.path(java_home)
+    if not java_home_path.exists:
+        fail('The path indicated by the "java_home" attribute "%s" (absolute: "%s") ' +
+             "does not exist." % (java_home, str(java_home_path)))
+
+    repository_ctx.file(
+        "WORKSPACE",
+        "# DO NOT EDIT: automatically generated WORKSPACE file for local_java_repository\n" +
+        "workspace(name = \"{name}\")\n".format(name = repository_ctx.name),
+    )
+
+    extension = ".exe" if repository_ctx.os.name.lower().find("windows") != -1 else ""
+    java_bin = java_home_path.get_child("bin").get_child("java" + extension)
+
+    if not java_bin.exists:
+        # Java binary does not exist
+        repository_ctx.file(
+            "BUILD.bazel",
+            _NOJDK_BUILD_TPL.format(
+                local_jdk = repository_ctx.name,
+                java_binary = "bin/java" + extension,
+                java_home = java_home,
+            ),
+            False,
+        )
+        return
+
+    # Detect version
+    version = repository_ctx.attr.version if repository_ctx.attr.version != "" else _detect_java_version(repository_ctx, java_bin)
+
+    # Prepare BUILD file using "local_java_runtime" macro
+    build_file = ""
+    if repository_ctx.attr.build_file != None:
+        build_file = repository_ctx.read(repository_ctx.path(repository_ctx.attr.build_file))
+
+    runtime_name = '"jdk"' if repository_ctx.attr.build_file else None
+    local_java_runtime_macro = """
+local_java_runtime(
+    name = "%s",
+    runtime_name = %s,
+    java_home = "%s",
+    version = "%s",
+)
+""" % (repository_ctx.name, runtime_name, java_home, version)
+
+    repository_ctx.file(
+        "BUILD.bazel",
+        'load("@bazel_tools//tools/jdk:local_java_repository.bzl", "local_java_runtime")\n' +
+        build_file +
+        local_java_runtime_macro,
+    )
+
+    # Symlink all files
+    for file in repository_ctx.path(java_home).readdir():
+        repository_ctx.symlink(file, file.basename)
+
+# Build file template, when JDK does not exist
+_NOJDK_BUILD_TPL = '''load("@bazel_tools//tools/jdk:fail_rule.bzl", "fail_rule")
+fail_rule(
+   name = "jdk",
+   header = "Auto-Configuration Error:",
+   message = ("Cannot find Java binary {java_binary} in {java_home}; either correct your JAVA_HOME, " +
+          "PATH or specify Java from remote repository (e.g. " +
+          "--java_runtime_version=remotejdk_11")
+)
+config_setting(
+   name = "localjdk_setting",
+   values = {{"java_runtime_version": "{local_jdk}"}},
+   visibility = ["//visibility:private"],
+)
+toolchain(
+   name = "runtime_toolchain_definition",
+   target_settings = [":localjdk_setting"],
+   toolchain_type = "@bazel_tools//tools/jdk:runtime_toolchain_type",
+   toolchain = ":jdk",
+)
+'''
+
+_local_java_repository_rule = repository_rule(
+    implementation = _local_java_repository_impl,
+    local = True,
+    configure = True,
+    attrs = {
+        "java_home": attr.string(),
+        "version": attr.string(),
+        "build_file": attr.label(),
+    },
+)
+
+def local_java_repository(name, java_home, version = "", build_file = None):
+    """Registers a runtime toolchain for local JDK and creates an unregistered compile toolchain.
+
+    Toolchain resolution is constrained with --java_runtime_version flag
+    having value of the "name" or "version" parameter.
+
+    Java compile toolchains are created for --java_language_version flags values
+    between 8 and version (inclusive). Java compile toolchains use the same
+    (local) JDK for compilation.
+
+    If there is no JDK "virtual" targets are created, which fail only when actually needed.
+
+    Args:
+      name: A unique name for this rule.
+      java_home: Location of the JDK imported.
+      build_file: optionally BUILD file template
+      version: optionally java version
+    """
+    _local_java_repository_rule(name = name, java_home = java_home, version = version, build_file = build_file)
+    native.register_toolchains("@" + name + "//:runtime_toolchain_definition")


### PR DESCRIPTION
My toolchain understanding is very superficial but this seems to work for us on https://github.com/digital-asset/daml and from what I can tell (via --toolchain_resolution_debug) the right toolchain is being selected.

I wasn’t quite sure how to handle backwards compatibility. Doing something magic based on the Bazel version would work I think but being explicit seemed like the nicer option.