### PR TITLE
Fix python example build on macOS

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -64,8 +64,6 @@ jobs:
           without_nix=( cc go rust )
 
           if [ "${{ runner.os }}" == "macOS" ]; then
-            # Python - https://github.com/tweag/rules_nixpkgs/issues/186
-            skip with_nix python
             # Rust - https://github.com/tweag/rules_nixpkgs/issues/187
             skip with_nix rust
             skip without_nix rust


### PR DESCRIPTION
Add `bash` if necessary to the `#!` line of the Python scripts. Leverage makeScriptWriter from nixpkgs that includes fix NixOS/nixpkgs#93757 for macOS compatibility.

Fixes #186