### PR TITLE
Recognize get_cpu_value "darwin_arm64"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1493,7 +1493,7 @@ default is <code>None</code>
 ### nixpkgs_sh_posix_configure
 
 <pre>
-nixpkgs_sh_posix_configure(<a href="#nixpkgs_sh_posix_configure-name">name</a>, <a href="#nixpkgs_sh_posix_configure-packages">packages</a>, <a href="#nixpkgs_sh_posix_configure-kwargs">kwargs</a>)
+nixpkgs_sh_posix_configure(<a href="#nixpkgs_sh_posix_configure-name">name</a>, <a href="#nixpkgs_sh_posix_configure-packages">packages</a>, <a href="#nixpkgs_sh_posix_configure-exec_constraints">exec_constraints</a>, <a href="#nixpkgs_sh_posix_configure-kwargs">kwargs</a>)
 </pre>
 
 Create a POSIX toolchain from nixpkgs.
@@ -1538,6 +1538,20 @@ default is <code>["stdenv.initialPath"]</code>
 <p>
 
 List of Nix attribute paths to draw Unix tools from.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_sh_posix_configure-exec_constraints">
+<td><code>exec_constraints</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+Constraints for the execution platform.
 
 </p>
 </td>

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,19 +29,10 @@ nixpkgs_local_repository(
     nix_file_deps = ["@rules_nixpkgs_core//:nixpkgs.json"],
 )
 
-# This is the commit introducing a Nix version working in the Bazel
-# sandbox
-nixpkgs_git_repository(
-    name = "remote_nixpkgs_for_nix_unstable",
-    remote = "https://github.com/NixOS/nixpkgs",
-    revision = "15d1011615d16a8b731adf28e2cfc33481102780",
-    sha256 = "8b1161a249d50effea1f240c34a81832a88c8d5d274314ae6225fd78bd62dfb9",
-)
-
 nixpkgs_package(
-    name = "nix-unstable",
-    attribute_path = "nixUnstable",
-    repositories = {"nixpkgs": "@remote_nixpkgs_for_nix_unstable"},
+    name = "nix_2_4",
+    attribute_path = "nix_2_4",
+    repositories = {"nixpkgs": "@nixpkgs"},
 )
 
 # This is used to run Nix in a sandboxed Bazel test. See the test

--- a/core/nixpkgs.nix
+++ b/core/nixpkgs.nix
@@ -1,5 +1,5 @@
 let
-  # nixpkgs-unstable as of 2021-02-19
+  # nixpkgs 21.11
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/core/util.bzl
+++ b/core/util.bzl
@@ -96,6 +96,51 @@ def find_children(repository_ctx, target_dir):
     exec_result = execute_or_fail(repository_ctx, find_args)
     return exec_result.stdout.rstrip("\000").split("\000")
 
+def default_constraints(repository_ctx):
+    """Calculate the default CPU and OS constraints based on the host platform.
+
+    Args:
+      repository_ctx: The repository context of the current repository rule.
+
+    Returns:
+      A list containing the cpu and os constraints.
+    """
+    cpu_value = get_cpu_value(repository_ctx)
+    cpu = {
+        "darwin": "@platforms//cpu:x86_64",
+        "darwin_arm64": "@platforms//cpu:arm64",
+    }.get(cpu_value, "@platforms//cpu:x86_64")
+    os = {
+        "darwin": "@platforms//os:osx",
+        "darwin_arm64": "@platforms//os:osx",
+    }.get(cpu_value, "@platforms//os:linux")
+    return [cpu, os]
+
+def ensure_constraints_pure(default_constraints, target_constraints = [], exec_constraints = []):
+    """Build exec and target constraints for repository rules.
+
+    If these are user-provided, then they are passed through.
+    Otherwise, use the provided default constraints.
+    In either case, exec_constraints always contain the support_nix constraint, so the toolchain can be rejected on non-Nix environments.
+
+    Args:
+      target_constraints: optional, User provided target_constraints.
+      exec_constraints: optional, User provided exec_constraints.
+      default_constraints: Fall-back constraints.
+
+    Returns:
+      exec_constraints, The generated list of exec constraints
+      target_constraints, The generated list of target constraints
+    """
+    if not target_constraints and not exec_constraints:
+        target_constraints = default_constraints
+        exec_constraints = target_constraints
+    else:
+        target_constraints = list(target_constraints)
+        exec_constraints = list(exec_constraints)
+    exec_constraints.append("@rules_nixpkgs_core//constraints:support_nix")
+    return exec_constraints, target_constraints
+
 def ensure_constraints(repository_ctx):
     """Build exec and target constraints for repository rules.
 
@@ -110,23 +155,11 @@ def ensure_constraints(repository_ctx):
       exec_constraints, The generated list of exec constraints
       target_constraints, The generated list of target constraints
     """
-    cpu_value = get_cpu_value(repository_ctx)
-    cpu = {
-        "darwin": "@platforms//cpu:x86_64",
-        "darwin_arm64": "@platforms//cpu:arm64",
-    }.get(cpu_value, "@platforms//cpu:x86_64")
-    os = {
-        "darwin": "@platforms//os:osx",
-        "darwin_arm64": "@platforms//os:osx",
-    }.get(cpu_value, "@platforms//os:linux")
-    if not repository_ctx.attr.target_constraints and not repository_ctx.attr.exec_constraints:
-        target_constraints = [cpu, os]
-        exec_constraints = target_constraints
-    else:
-        target_constraints = list(repository_ctx.attr.target_constraints)
-        exec_constraints = list(repository_ctx.attr.exec_constraints)
-    exec_constraints.append("@rules_nixpkgs_core//constraints:support_nix")
-    return exec_constraints, target_constraints
+    return ensure_constraints_pure(
+        default_constraints = default_constraints(repository_ctx),
+        target_constraints = repository_ctx.attr.target_constraints,
+        exec_constraints = repository_ctx.attr.exec_constraints,
+    )
 
 def parse_expand_location(string):
     """Parse a string that might contain location expansion commands.

--- a/core/util.bzl
+++ b/core/util.bzl
@@ -110,15 +110,15 @@ def ensure_constraints(repository_ctx):
       exec_constraints, The generated list of exec constraints
       target_constraints, The generated list of target constraints
     """
-    cpu = get_cpu_value(repository_ctx)
+    cpu_value = get_cpu_value(repository_ctx)
     cpu = {
         "darwin": "@platforms//cpu:x86_64",
         "darwin_arm64": "@platforms//cpu:arm64",
-    }.get(cpu, "@platforms//cpu:x86_64")
+    }.get(cpu_value, "@platforms//cpu:x86_64")
     os = {
         "darwin": "@platforms//os:osx",
         "darwin_arm64": "@platforms//os:osx",
-    }.get(cpu, "@platforms//os:linux")
+    }.get(cpu_value, "@platforms//os:linux")
     if not repository_ctx.attr.target_constraints and not repository_ctx.attr.exec_constraints:
         target_constraints = [cpu, os]
         exec_constraints = target_constraints

--- a/examples/toolchains/cc/nixpkgs.nix
+++ b/examples/toolchains/cc/nixpkgs.nix
@@ -1,5 +1,5 @@
 let
-  # nixpkgs-unstable as of 2021-02-19
+  # nixpkgs 21.11
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/examples/toolchains/cc_with_deps/nixpkgs.nix
+++ b/examples/toolchains/cc_with_deps/nixpkgs.nix
@@ -1,5 +1,5 @@
 let
-  # nixpkgs-unstable as of 2021-02-19
+  # nixpkgs 21.11
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/examples/toolchains/go/nixpkgs.nix
+++ b/examples/toolchains/go/nixpkgs.nix
@@ -1,5 +1,5 @@
 let
-  # nixpkgs-unstable as of 2021-02-19
+  # nixpkgs 21.11
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/examples/toolchains/java/nixpkgs.nix
+++ b/examples/toolchains/java/nixpkgs.nix
@@ -1,5 +1,5 @@
 let
-  # nixpkgs-unstable as of 2021-02-21
+  # nixpkgs as of 2022-02-21
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/examples/toolchains/python/nixpkgs.nix
+++ b/examples/toolchains/python/nixpkgs.nix
@@ -1,5 +1,5 @@
 let
-  # nixpkgs-unstable as of 2021-02-19
+  # nixpkgs 21.11
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/examples/toolchains/rust/nixpkgs.nix
+++ b/examples/toolchains/rust/nixpkgs.nix
@@ -1,5 +1,5 @@
 let
-  # nixpkgs-unstable as of 2021-02-19
+  # nixpkgs 21.11
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -8,7 +8,7 @@ sh_test(
         "//nixpkgs:srcs",
         "//tests/invalid_nixpkgs_package:srcs",
         "@coreutils_static//:bin",
-        "@nix-unstable//:bin",
+        "@nix_2_4//:bin",
         "@rules_nixpkgs_cc//:srcs",
         "@rules_nixpkgs_core//:srcs",
         "@rules_nixpkgs_java//:srcs",

--- a/tests/test_invalid_nixpkgs_package.sh
+++ b/tests/test_invalid_nixpkgs_package.sh
@@ -17,7 +17,7 @@ sed "s;COREUTILS-ABS-PATH;${PWD}/external/coreutils_static/bin/;g" -i default.ni
 
 # Bring a specific version of Nix which can be executed in the Bazel
 # linux sandbox.
-export PATH=$PWD/external/nix-unstable/bin:$PATH
+export PATH=$PWD/external/nix_2_4/bin:$PATH
 
 # This is a create all directories required to run Nix locally.
 mkdir -p ${TEST_TMPDIR}/nix/{store,var/nix,etc/nix}

--- a/toolchains/cc/cc.bzl
+++ b/toolchains/cc/cc.bzl
@@ -109,7 +109,7 @@ def _parse_cc_toolchain_info(content, filename):
 
 def _nixpkgs_cc_toolchain_config_impl(repository_ctx):
     cpu_value = get_cpu_value(repository_ctx)
-    darwin = cpu_value == "darwin"
+    darwin = cpu_value == "darwin" or cpu_value == "darwin_arm64"
 
     cc_toolchain_info_file = repository_ctx.path(repository_ctx.attr.cc_toolchain_info)
     if not cc_toolchain_info_file.exists and not repository_ctx.attr.fail_not_supported:

--- a/toolchains/go/go.bzl
+++ b/toolchains/go/go.bzl
@@ -8,7 +8,6 @@ Rules for importing a Go toolchain from Nixpkgs.
 """
 
 load("@rules_nixpkgs_core//:nixpkgs.bzl", "nixpkgs_package")
-load("@bazel_tools//tools/cpp:lib_cc_configure.bzl", "get_cpu_value")
 load("@io_bazel_rules_go//go/private:platforms.bzl", "PLATFORMS")
 
 def _detect_host_platform(ctx):
@@ -150,7 +149,6 @@ declare_toolchains("{goos}", "{goarch}")
 """
 
 def _nixpkgs_go_toolchain_impl(repository_ctx):
-    cpu = get_cpu_value(repository_ctx)
     goos, goarch = _detect_host_platform(repository_ctx)
     content = go_toolchain_func.format(
         sdk_repo = repository_ctx.attr.sdk_repo,

--- a/toolchains/posix/README.md
+++ b/toolchains/posix/README.md
@@ -16,7 +16,7 @@ Rules for importing a POSIX toolchain from Nixpkgs.
 ### nixpkgs_sh_posix_configure
 
 <pre>
-nixpkgs_sh_posix_configure(<a href="#nixpkgs_sh_posix_configure-name">name</a>, <a href="#nixpkgs_sh_posix_configure-packages">packages</a>, <a href="#nixpkgs_sh_posix_configure-kwargs">kwargs</a>)
+nixpkgs_sh_posix_configure(<a href="#nixpkgs_sh_posix_configure-name">name</a>, <a href="#nixpkgs_sh_posix_configure-packages">packages</a>, <a href="#nixpkgs_sh_posix_configure-exec_constraints">exec_constraints</a>, <a href="#nixpkgs_sh_posix_configure-kwargs">kwargs</a>)
 </pre>
 
 Create a POSIX toolchain from nixpkgs.
@@ -61,6 +61,20 @@ default is <code>["stdenv.initialPath"]</code>
 <p>
 
 List of Nix attribute paths to draw Unix tools from.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_sh_posix_configure-exec_constraints">
+<td><code>exec_constraints</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+<p>
+
+Constraints for the execution platform.
 
 </p>
 </td>

--- a/toolchains/posix/posix.bzl
+++ b/toolchains/posix/posix.bzl
@@ -109,6 +109,7 @@ create_posix_toolchain()
 def _nixpkgs_sh_posix_toolchain_impl(repository_ctx):
     exec_constraints, _ = ensure_constraints_pure(
         default_constraints = default_constraints(repository_ctx),
+        exec_constraints = repository_ctx.attr.exec_constraints,
     )
     repository_ctx.file("BUILD", executable = False, content = """
 toolchain(
@@ -129,12 +130,14 @@ _nixpkgs_sh_posix_toolchain = repository_rule(
     _nixpkgs_sh_posix_toolchain_impl,
     attrs = {
         "workspace": attr.string(),
+        "exec_constraints": attr.string_list(),
     },
 )
 
 def nixpkgs_sh_posix_configure(
         name = "nixpkgs_sh_posix_config",
         packages = ["stdenv.initialPath"],
+        exec_constraints = None,
         **kwargs):
     """Create a POSIX toolchain from nixpkgs.
 
@@ -148,6 +151,7 @@ def nixpkgs_sh_posix_configure(
     Args:
       name: Name prefix for the generated repositories.
       packages: List of Nix attribute paths to draw Unix tools from.
+      exec_constraints: Constraints for the execution platform.
       nix_file_deps: See nixpkgs_package.
       repositories: See nixpkgs_package.
       repository: See nixpkgs_package.
@@ -157,6 +161,7 @@ def nixpkgs_sh_posix_configure(
     nixpkgs_sh_posix_config(
         name = name,
         packages = packages,
+        exec_constraints = exec_constraints,
         **kwargs
     )
 


### PR DESCRIPTION
On an M1 Mac `get_cpu_value` will return `darwin_arm64` instead of `darwin`.
This PR adapts our platform constraint detection to take that case into account.

Note, if bazel runs as an x86_64 binary under Rosetta, then `get_cpu_value` will still report `darwin`.
So, under Rosetta this will consistently use `x86_64` constraints.

This also removes an unused instance of `get_cpu_value` in the Go toolchain.