### PR TITLE
Reinstate the `merge-queue` label for Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,11 +14,11 @@ pull_request_rules:
       - "label=merge-queue"
     actions:
       queue:
-       
+        name: default
   - name: remove from merge-queue after merge
     conditions:
       - merged
     actions:
       label:
         remove:
-          - "merge-queue" name: default
+          - "merge-queue"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,6 +11,14 @@ pull_request_rules:
       - check-success~=Build & Test - Nixpkgs \(.*\)
       - check-success~=Build & Test - Examples \(.*\)
       - "#approved-reviews-by>=1"
+      - "label=merge-queue"
     actions:
       queue:
-        name: default
+       
+  - name: remove from merge-queue after merge
+    conditions:
+      - merged
+    actions:
+      label:
+        remove:
+          - "merge-queue" name: default


### PR DESCRIPTION
It looks like it was lost in [#178](https://github.com/tweag/rules_nixpkgs/pull/178/files#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2L7).
C.f. [rules_haskell's mergify config](https://github.com/tweag/rules_haskell/blob/4c8e6d3b83122ee43949994f4343697d98dbe281/.mergify.yml).