### PR TITLE
Fix call to `repository_ctx.file` using `nix_file_content` with `nixpkgs_local_repository`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,6 +51,13 @@ nixpkgs_local_repository(
     nix_file_deps = ["//:nixpkgs.json"],
 )
 
+# same as @nixpkgs but using the `nix_file_content` parameter
+nixpkgs_local_repository(
+    name = "nixpkgs_content",
+    nix_file_content = "import ./nixpkgs.nix",
+    nix_file_deps = ["//:nixpkgs.nix", "//:nixpkgs.json"],
+)
+
 # This is the commit introducing a Nix version working in the Bazel
 # sandbox
 nixpkgs_git_repository(
@@ -70,6 +77,12 @@ nixpkgs_package(
     name = "nixpkgs-git-repository-test",
     attribute_path = "hello",
     repositories = {"nixpkgs": "@remote_nixpkgs"},
+)
+
+nixpkgs_package(
+    name = "nixpkgs-local-repository-test",
+    nix_file_content = "with import <nixpkgs> {}; hello",
+    repositories = {"nixpkgs": "@nixpkgs_content"},
 )
 
 nixpkgs_package(

--- a/core/nixpkgs.bzl
+++ b/core/nixpkgs.bzl
@@ -77,12 +77,12 @@ def _nixpkgs_local_repository_impl(repository_ctx):
        bool(repository_ctx.attr.nix_file_content):
         fail("Specify one of 'nix_file' or 'nix_file_content' (but not both).")
     if repository_ctx.attr.nix_file_content:
+        target = "default.nix"
         repository_ctx.file(
-            path = "default.nix",
+            target,
             content = repository_ctx.attr.nix_file_content,
             executable = False,
         )
-        target = repository_ctx.path("default.nix")
     else:
         target = cp(repository_ctx, repository_ctx.attr.nix_file)
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -27,6 +27,7 @@ expand_location_unit_test_suite()
         "nix-file-test",
         "nix-file-deps-test",
         "nixpkgs-git-repository-test",
+        "nixpkgs-local-repository-test",
         "relative-imports",
     ]
 ] + [


### PR DESCRIPTION
```
ERROR: An error occurred during the fetch of repository 'nixpkgs':
   Traceback (most recent call last):
	File "/home/claudio/.cache/bazel/_bazel_claudio/c7ff5b30a595e0e5def985dcafaa7d4c/external/io_tweag_rules_nixpkgs/nixpkgs/nixpkgs.bzl", line 54, column 28, in _nixpkgs_local_repository_impl
		repository_ctx.file(
Error in file: file() got named argument for positional-only parameter 'path'
```

Fixes #140.
