### PR TITLE
Add ::group:: for each example to GitHub workflow logs

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -72,7 +72,7 @@ jobs:
           for dir in "${with_nix[@]}"; do
               cd "$dir"
               echo
-              echo Running $(head -n1 README.md) with Nix
+              echo "::group::Running $(head -n1 README.md) with Nix"
               nix-shell --command 'bazel run --config=nix :hello'
               # TODO: all toolchains should run without Nixpkgs
               cd ..
@@ -80,7 +80,7 @@ jobs:
           for dir in "${without_nix[@]}"; do
               cd "$dir"
               echo
-              echo Running $(head -n1 README.md) without Nix
+              echo "::group::Running $(head -n1 README.md) without Nix"
               bazel run :hello
               cd ..
           done


### PR DESCRIPTION
It should make it easier to find the exact example in logs. See run for this commit for an example: https://github.com/tweag/rules_nixpkgs/runs/5736918187