### PR TITLE
Rule to generate docker images with nix store paths

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -281,3 +281,17 @@ nixpkgs_go_configure(repository = "@nixpkgs")
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies")
 
 go_rules_dependencies()
+
+load("//experimental:docker.bzl", "nixpkgs_docker_image")
+
+# Usage:
+#   - building: `bazel build @docker_image//:image`
+#   - streaming: `bazel run @docker_image//:stream | gzip --fast | skopeo copy docker-archive:/dev/stdin docker://some.registry/docker_image:latest`
+nixpkgs_docker_image(
+    name = "docker_image",
+    srcs = [
+        "@hello//nixpkg",
+        "@nixpkgs_config_cc_info//nixpkg",
+    ],
+    repositories = {"nixpkgs": "@nixpkgs"},
+)

--- a/core/BUILD.repo
+++ b/core/BUILD.repo
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "srcs",
+    srcs = %{srcs},
+)

--- a/core/default.nix.tpl
+++ b/core/default.nix.tpl
@@ -1,0 +1,12 @@
+{%{args_with_defaults}}:
+let
+  x = %{def};
+  y = if builtins.isFunction x then
+        let
+          formalArgs = builtins.functionArgs x;
+          actualArgs = builtins.intersectAttrs formalArgs {inherit %{args};};
+        in
+           x actualArgs
+       else x;
+in
+  y%{maybe_sel}

--- a/core/util.bzl
+++ b/core/util.bzl
@@ -19,11 +19,7 @@ def cp(repository_ctx, src, dest = None):
     if dest == None:
         if type(src) != "Label":
             fail("src must be a Label if dest is not specified explicitly.")
-        dest = "/".join([
-            component
-            for component in [src.workspace_root, src.package, src.name]
-            if component
-        ])
+        dest = label_to_path(src)
 
     # Copy the file
     repository_ctx.file(
@@ -64,6 +60,14 @@ Error output:
 {stderr}
 """.format(**outputs))
     return result
+
+def label_to_path(label, prefix=None):
+    prefix = [prefix] if prefix else []
+    return "/".join(prefix + [
+        component
+        for component in [label.workspace_root, label.package, label.name]
+        if component
+    ])
 
 def label_string(label):
     """Convert the given (optional) Label to a string."""

--- a/experimental/BUILD.bazel
+++ b/experimental/BUILD.bazel
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+exports_files([
+  "docker/stream.sh",
+])
+
+bzl_library(
+    name = "docker",
+    srcs = [
+        "docker.bzl",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/experimental/docker.bzl
+++ b/experimental/docker.bzl
@@ -1,0 +1,91 @@
+def _nixpkgs_docker_image_impl(repository_ctx):
+    repositories = repository_ctx.attr.repositories
+
+    nix_build_bin = repository_ctx.which("nix-build")
+    repository_ctx.symlink(nix_build_bin, "nix-build")
+
+    srcs = repository_ctx.attr.srcs
+    bazel = repository_ctx.attr.bazel
+
+    # HACK! On bazel from nixpkgs, shebangs get mangled in things like
+    # @bazel_tools//tools/cpp:linux_cc_wrapper.sh.tpl, so that nix store
+    # paths end up referenced there.
+    # One needs to ensure those paths are available on the docker image
+    # as well, we can do that by including bazel
+    srcs = srcs + [bazel] if bazel else srcs
+
+    contents = []
+    for src in srcs:
+        path_to_default_nix = repository_ctx.path(src.relative("default.nix"))
+        package = "nixpkgs/%s" % src.workspace_name
+        repository_ctx.symlink(path_to_default_nix.dirname, package)
+        contents.append("(import ./%s {})" % package)
+
+    repository_ctx.template(
+        "default.nix",
+        Label("@io_tweag_rules_nixpkgs//experimental:docker/default.nix.template"),
+        substitutions = {
+            "%{name}": repr(repository_ctx.name),
+            "%{contents}": "\n    ".join(contents),
+        },
+        executable=False,
+    )
+
+    for repo in repositories.keys():
+        path = str(repository_ctx.path(repo).dirname) + "/nix-file-deps"
+        if repository_ctx.path(path).exists:
+            content = repository_ctx.read(path)
+            for f in content.splitlines():
+                # Hack: this is to register all Nix files as dependencies
+                # of this rule (see issue #113)
+                repository_ctx.path(repo.relative(":{}".format(f)))
+
+    args = list(repository_ctx.attr.nixopts)
+    deps = []
+    for repo_label, repo_name in repositories.items():
+        args.extend([
+            '"-I"',
+            repr("%s=$(location %s)" % (repo_name, repo_label))
+        ])
+        deps.extend([
+            repo_label,
+            repo_label.relative(":srcs"),
+        ])
+
+    repository_ctx.template(
+        "BUILD",
+        Label("@io_tweag_rules_nixpkgs//experimental:docker/BUILD.template"),
+        substitutions = {
+            "%{args_comma_sep}": ",\n        ".join(args),
+            "%{args_space_sep}": " ".join(args),
+            "%{repo_labels}": ",\n        ".join([repr(str(dep)) for dep in deps])
+        },
+        executable=False,
+    )
+
+
+
+_nixpkgs_docker_image = repository_rule(
+    implementation = _nixpkgs_docker_image_impl,
+    attrs = {
+        "nixopts": attr.string_list(),
+        "repositories": attr.label_keyed_string_dict(),
+        "srcs": attr.label_list(
+            doc = 'List of nixpkgs_package to include in the image. E.g. ["@hello//nixpkg"]',
+        ),
+        "bazel": attr.label(
+            doc = """If using bazel from nixpkgs, this a nixpackage_package
+            based on exactly the same bazel derivation. This is to ensure any paths
+            for mangled '/usr/env bash' introduced by nix exist in the store.
+            Example: '<nixpkgs>.bazel_4'.
+            """
+        ),
+    },
+)
+
+def nixpkgs_docker_image(name, **kwargs):
+    repositories = kwargs.get("repositories")
+    if repositories:
+        inversed_repositories = {value: key for key, value in repositories.items()}
+        kwargs["repositories"] = inversed_repositories
+    _nixpkgs_docker_image(name=name, **kwargs)

--- a/experimental/docker/BUILD.template
+++ b/experimental/docker/BUILD.template
@@ -1,0 +1,31 @@
+sh_binary(
+    name = "stream",
+    srcs = ["@io_tweag_rules_nixpkgs//experimental:docker/stream.sh"],
+    data = [
+        ":default.nix",
+        ":nix-build",
+        %{repo_labels}
+    ],
+    env = {"NIX_BUILD": "$(location :nix-build)"},
+    args = [
+        "$(location :default.nix)",
+        %{args_comma_sep}
+    ],
+)
+
+genrule(
+    name = "image",
+    srcs = [
+        ":default.nix",
+        %{repo_labels}
+    ],
+    outs = ["image.tgz"],
+    exec_tools = [":nix-build"],
+    cmd = """
+    $(location :nix-build) %{args_space_sep} \
+      --arg stream false \
+      --out-link $@ \
+      $(location :default.nix)
+    """,
+    local = True,
+)

--- a/experimental/docker/default.nix.template
+++ b/experimental/docker/default.nix.template
@@ -1,0 +1,47 @@
+{ stream ? true, tag ? null, nixpkgs ? import <nixpkgs> {} }:
+
+let
+  dockerImage = if stream
+    then nixpkgs.dockerTools.streamLayeredImage
+    else nixpkgs.dockerTools.buildLayeredImage;
+
+  name = %{name};
+
+  contents = [
+    %{contents}
+  ];
+
+  manifest = nixpkgs.writeTextFile
+    { name = "${name}-MANIFEST";
+      text = nixpkgs.lib.strings.concatMapStrings (pkg: "${pkg}\n") contents;
+      destination = "/MANIFEST";
+    };
+
+  usr_bin_env = nixpkgs.runCommand "usr-bin-env" {} ''
+    mkdir -p "$out/usr/bin/"
+    ln -s "${nixpkgs.coreutils}/bin/env" "$out/usr/bin/"
+  '';
+in
+  dockerImage {
+    inherit name tag;
+
+    contents = [
+      # Contents get copied to the top-level of the image, so we jus putt
+      # a short manifest file here and get all the store paths as dependencies
+      manifest
+
+      # Ensure "/usr/bin/env bash" works correctly
+      nixpkgs.bash
+      nixpkgs.coreutils
+      usr_bin_env
+
+      # avoid "commitBuffer: invalid argument (invalid character)" running tests
+      nixpkgs.glibcLocales
+    ];
+
+    extraCommands = "mkdir -m 0777 tmp";
+
+    config = {
+      Cmd = [ "${nixpkgs.bashInteractive}/bin/bash" ];
+    };
+  }

--- a/experimental/docker/stream.sh
+++ b/experimental/docker/stream.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+run() {
+  ${NIX_BUILD} --arg stream true "$@"
+}
+
+$(run "$@")


### PR DESCRIPTION
**Context**: I'm currently using bazel with remote execution using this branch; it's not an ideal solution, but it's a first step and there could be other people interested in trying it out.

The goal was to have a docker image that contains all the nix store paths that occur in the workspace, so that the remote executors also inherit them. For this, I'm introducing a repository rule `nixpkgs_docker_image`, that I'm then using in my workspace as follows:

```bzl
nixpkgs_docker_image(
    name = "nix_deps_image",
    srcs = [
        "@cc_toolchain_nixpkgs_info//nixpkg",
        "@nixpkgs_python_toolchain_python3//nixpkg",
        "@nixpkgs_sh_posix_config//nixpkg",
        "@rules_haskell_ghc_nixpkgs//nixpkg",
        "@nixpkgs_valgrind//nixpkg",
    ],
    bazel = "@nixpkgs_bazel//nixpkg",
    repositories = {"nixpkgs": "@nixpkgs"},
)
```

In `srcs`, one should include every usage of the `nixpkgs_package` rule, either explicit (as `@nixpkgs_valgrind` in this example) or implicit as those coming from the toolchain rules. One then gets two targets:

  - `@nix_deps_image//:image`: a `genrule` that uses `dockerTools.buildLayeredImage` to build a tarball
  - `@nix_deps_image//:stream`: a `sh_binary` that uses `dockerTools.streamLayeredImage` to output the tarball on stdout.

One then needs to ensure that the docker image is available before starting a remote build, either by manually pushing the image, or running a CI step.

All this relies on the `nixpkgs_package` rule creating a `nixpkg` subpackage in the package repository, containing the exact nix-expression used by `nix-build` to create the package. Ideally, this would all be more transparent to the user, who would just mention the toolchain and the package in `srcs` and the rule would figure out the rest, but for a proof-of-concept this is enough.

The funny bit is in the `bazel` argument, what's this about? There is an unexpected issue coming from using bazel provisioned by nixpkgs (which I guess is the most common case for `rules_nixpkgs` users): internal bazel files like `@bazel_tools//tools/cpp:linux_cc_wrapper.sh.tpl` get the shebang mangled so that `#!/usr/bin/env bash`, becomes, say `#!/nix/store/5nr4gffsb5l72xpz6d5jbd0skih3r9i2-bash/bin/bash` and the problem is how to ensure that those paths ends up in the docker image as well. The workaround here is for the user to optionally provide a `nixpkgs_package` that should correspond to the exact same bazel being used on dev, CI, etc., so that whatever was used when mangling shebangs is available as a dependency.

As far as I can see, this issue goes beyond `rules_nixpkgs`, in that a nixpkgs-provisioned bazel is hard to use with remote execution and may require some upstream fix. I think all the possible approaches listed in #180 would be affected by this.