### PR TITLE
cc: Remove explicit CXX_FLAG

### DIFF
--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -161,7 +161,6 @@ in
         -fno-omit-frame-pointer
       )
       CXX_FLAGS=(
-        -x c++
         -std=c++0x
       )
       LINK_FLAGS=(


### PR DESCRIPTION
Ran workflows on my branch and it seemed to work (except the hooks that need buildbuddy)
https://github.com/AnotherGroupChat/rules_nixpkgs/actions/runs/2157830144

Just seeing how #218 influences your tests. Let me know if there is a better way- but vanilla bazel does not add this flag

Opening as a draft as you all may have better ideas on how to implement this