### PR TITLE
Allow graceful failure when unable to capture external includes

### DIFF
--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -138,7 +138,7 @@ pkgs.runCommand "bazel-nixpkgs-cc-toolchain"
       $cc -E -x "$1" - -v "''${@:2}" 2>&1 \
         | sed -e '1,/^#include <...>/d;/^[^ ]/,$d;s/^ *//' -e 's: (framework directory)::g' \
         | tr '\n' '\0' \
-        | xargs -0 realpath -ms
+        | xargs -0 realpath -ms || :
     }
     CXX_BUILTIN_INCLUDE_DIRECTORIES=($({
       include_dirs_for c


### PR DESCRIPTION
Currently for something like clang-unwrapped nothing is grepped so this fails