### PR TITLE
Use `nix-support/cc-{c,ld}flags` files to configure compiler flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,37 @@ tools. Tools that aren't found are replaced by `${coreutils}/bin/false`.
 You can inspect the resulting `@<name>_info//:CC_TOOLCHAIN_INFO` to see
 which tools were discovered.
 
+If you specify the `nix_file` or `nix_file_content` argument, the CC
+toolchain is discovered by evaluating the corresponding expression. In
+addition, you may use the `attribute_path` argument to select an attribute
+from the result of the expression to use as the CC toolchain (see example below).
+
+If neither the `nix_file` nor `nix_file_content` argument is used, the
+toolchain is discovered from the `stdenv.cc` and the `stdenv.cc.bintools`
+attributes of the given `<nixpkgs>` repository.
+
+```
+# use GCC 11
+nixpkgs_cc_configure(
+  repository = "@nixpkgs",
+  nix_file_content = "(import <nixpkgs> {}).gcc11",
+)
+```
+```
+# use GCC 11 (same result as above)
+nixpkgs_cc_configure(
+  repository = "@nixpkgs",
+  attribute_path = "gcc11",
+  nix_file_content = "import <nixpkgs> {}",
+)
+```
+```
+# use the `stdenv.cc` compiler (the default of the given @nixpkgs repository)
+nixpkgs_cc_configure(
+  repository = "@nixpkgs",
+)
+```
+
 This rule depends on [`rules_cc`](https://github.com/bazelbuild/rules_cc).
 
 **Note:**

--- a/toolchains/cc/README.md
+++ b/toolchains/cc/README.md
@@ -33,6 +33,37 @@ tools. Tools that aren't found are replaced by `${coreutils}/bin/false`.
 You can inspect the resulting `@<name>_info//:CC_TOOLCHAIN_INFO` to see
 which tools were discovered.
 
+If you specify the `nix_file` or `nix_file_content` argument, the CC
+toolchain is discovered by evaluating the corresponding expression. In
+addition, you may use the `attribute_path` argument to select an attribute
+from the result of the expression to use as the CC toolchain (see example below).
+
+If neither the `nix_file` nor `nix_file_content` argument is used, the
+toolchain is discovered from the `stdenv.cc` and the `stdenv.cc.bintools`
+attributes of the given `<nixpkgs>` repository.
+
+```
+# use GCC 11
+nixpkgs_cc_configure(
+  repository = "@nixpkgs",
+  nix_file_content = "(import <nixpkgs> {}).gcc11",
+)
+```
+```
+# use GCC 11 (same result as above)
+nixpkgs_cc_configure(
+  repository = "@nixpkgs",
+  attribute_path = "gcc11",
+  nix_file_content = "import <nixpkgs> {}",
+)
+```
+```
+# use the `stdenv.cc` compiler (the default of the given @nixpkgs repository)
+nixpkgs_cc_configure(
+  repository = "@nixpkgs",
+)
+```
+
 This rule depends on [`rules_cc`](https://github.com/bazelbuild/rules_cc).
 
 **Note:**

--- a/toolchains/cc/cc.bzl
+++ b/toolchains/cc/cc.bzl
@@ -302,6 +302,37 @@ def nixpkgs_cc_configure(
     You can inspect the resulting `@<name>_info//:CC_TOOLCHAIN_INFO` to see
     which tools were discovered.
 
+    If you specify the `nix_file` or `nix_file_content` argument, the CC
+    toolchain is discovered by evaluating the corresponding expression. In
+    addition, you may use the `attribute_path` argument to select an attribute
+    from the result of the expression to use as the CC toolchain (see example below).
+
+    If neither the `nix_file` nor `nix_file_content` argument is used, the
+    toolchain is discovered from the `stdenv.cc` and the `stdenv.cc.bintools`
+    attributes of the given `<nixpkgs>` repository.
+
+    ```
+    # use GCC 11
+    nixpkgs_cc_configure(
+      repository = "@nixpkgs",
+      nix_file_content = "(import <nixpkgs> {}).gcc11",
+    )
+    ```
+    ```
+    # use GCC 11 (same result as above)
+    nixpkgs_cc_configure(
+      repository = "@nixpkgs",
+      attribute_path = "gcc11",
+      nix_file_content = "import <nixpkgs> {}",
+    )
+    ```
+    ```
+    # use the `stdenv.cc` compiler (the default of the given @nixpkgs repository)
+    nixpkgs_cc_configure(
+      repository = "@nixpkgs",
+    )
+    ```
+
     This rule depends on [`rules_cc`](https://github.com/bazelbuild/rules_cc).
 
     **Note:**

--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -22,8 +22,8 @@ let
         echo "-F${CoreServices}/Library/Frameworks" >> $out/nix-support/cc-cflags
         echo "-F${Security}/Library/Frameworks" >> $out/nix-support/cc-cflags
         echo "-F${Foundation}/Library/Frameworks" >> $out/nix-support/cc-cflags
-        echo "-L${pkgs.libiconv}/lib" >> $out/nix-support/cc-ldflags
-        echo "-L${pkgs.darwin.libobjc}/lib" >> $out/nix-support/cc-ldflags
+        echo "-L${pkgs.libiconv}/lib" >> $out/nix-support/cc-cflags
+        echo "-L${pkgs.darwin.libobjc}/lib" >> $out/nix-support/cc-cflags
       '';
     };
   cc =

--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -34,25 +34,16 @@ let
     else
       pkgs.buildEnv (
         let
-          paths =
-            if pkgs.stdenv.isDarwin then
-              {
-                inherit (darwinCC) cc bintools;
-              }
-            else
-              {
-                cc = pkgs.stdenv.cc;
-                bintools = pkgs.binutils;
-              };
+          cc = if pkgs.stdenv.isDarwin then darwinCC else pkgs.stdenv.cc;
         in
         {
           name = "bazel-nixpkgs-cc";
           # XXX: `gcov` is missing in `/bin`.
           #   It exists in `stdenv.cc.cc` but that collides with `stdenv.cc`.
-          paths = [ paths.cc paths.bintools ];
+          paths = [ cc cc.bintools ];
           pathsToLink = [ "/bin" ];
           passthru = {
-            isClang = paths.cc.isClang;
+            isClang = cc.isClang;
           };
         }
       )

--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -17,11 +17,14 @@ let
       bintools = cc.bintools;
       extraBuildCommands = with pkgs.darwin.apple_sdk.frameworks; ''
         echo "-Wno-unused-command-line-argument" >> $out/nix-support/cc-cflags
-        echo "-isystem ${pkgs.llvmPackages.libcxx}/include/c++/v1" >> $out/nix-support/cc-cflags
+        echo "-isystem ${pkgs.llvmPackages.libcxx.dev}/include/c++/v1" >> $out/nix-support/cc-cflags
+        echo "-isystem ${pkgs.llvmPackages.clang-unwrapped.lib}/lib/clang/${cc.version}/include" >> $out/nix-support/cc-cflags
         echo "-F${CoreFoundation}/Library/Frameworks" >> $out/nix-support/cc-cflags
         echo "-F${CoreServices}/Library/Frameworks" >> $out/nix-support/cc-cflags
         echo "-F${Security}/Library/Frameworks" >> $out/nix-support/cc-cflags
         echo "-F${Foundation}/Library/Frameworks" >> $out/nix-support/cc-cflags
+        echo "-L${pkgs.llvmPackages.libcxx}/lib" >> $out/nix-support/cc-cflags
+        echo "-L${pkgs.llvmPackages.libcxxabi}/lib" >> $out/nix-support/cc-cflags
         echo "-L${pkgs.libiconv}/lib" >> $out/nix-support/cc-cflags
         echo "-L${pkgs.darwin.libobjc}/lib" >> $out/nix-support/cc-cflags
       '';

--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -9,12 +9,12 @@ in
 }:
 
 let
-
   darwinCC =
     # Work around https://github.com/NixOS/nixpkgs/issues/42059.
     # See also https://github.com/NixOS/nixpkgs/pull/41589.
     pkgs.wrapCCWith rec {
       cc = pkgs.stdenv.cc;
+      bintools = cc.bintools;
       extraBuildCommands = with pkgs.darwin.apple_sdk.frameworks; ''
         echo "-Wno-unused-command-line-argument" >> $out/nix-support/cc-cflags
         echo "-isystem ${pkgs.llvmPackages.libcxx}/include/c++/v1" >> $out/nix-support/cc-cflags
@@ -37,20 +37,19 @@ let
           paths =
             if pkgs.stdenv.isDarwin then
               {
-                cc = (pkgs.overrideCC pkgs.stdenv darwinCC).cc;
-                binutils = pkgs.darwin.binutils;
+                inherit (darwinCC) cc bintools;
               }
             else
               {
                 cc = pkgs.stdenv.cc;
-                binutils = pkgs.binutils;
+                bintools = pkgs.binutils;
               };
         in
         {
           name = "bazel-nixpkgs-cc";
           # XXX: `gcov` is missing in `/bin`.
           #   It exists in `stdenv.cc.cc` but that collides with `stdenv.cc`.
-          paths = [ paths.cc paths.binutils ];
+          paths = [ paths.cc paths.bintools ];
           pathsToLink = [ "/bin" ];
           passthru = {
             isClang = paths.cc.isClang;


### PR DESCRIPTION
# Purpose

This improves support for using rules_nixpkgs on Darwin where it is required to sign binaries.

Fixes #225 and fixes #224.
