### PR TITLE
Run all tests and accumulate failures on CI

### DIFF
--- a/.github/build-and-test
+++ b/.github/build-and-test
@@ -1,0 +1,47 @@
+#! /usr/bin/env nix-shell
+#! nix-shell ../shell.nix -i bash
+
+set -euo pipefail
+
+declare SCRIPT_DIR
+
+SCRIPT_DIR="$( realpath "${BASH_SOURCE[0]}" )"
+SCRIPT_DIR="${SCRIPT_DIR%/*}"
+
+cd "$( dirname "$SCRIPT_DIR" )"
+
+declare -i FAILED=0
+declare -a FAILURES=( )
+
+function on_exit() {
+    echo
+    if [[ "$FAILED" -gt 0 ]]; then
+        echo "error: running tests in ${FAILURES[@]} was not successful"
+        exit 1
+    elif [[ $? -eq 0 ]]; then
+        echo "all tests passed."
+    fi
+} >&2
+
+trap on_exit EXIT
+
+declare -ra dirs=(
+    .
+    core
+    toolchains/go
+    toolchains/java
+    toolchains/cc
+    toolchains/python
+    toolchains/posix
+    toolchains/rust
+)
+for dir in "${dirs[@]}"
+do
+    pushd $dir
+    if ! bazel test //... ; then
+        let ++FAILED
+        FAILURES+=( "$dir" )
+    fi
+    popd
+done
+

--- a/.github/build-and-test
+++ b/.github/build-and-test
@@ -42,6 +42,7 @@ do
         let ++FAILED
         FAILURES+=( "$dir" )
     fi
+    bazel shutdown
     popd
 done
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -25,7 +25,7 @@ jobs:
           EOF
       - name: Build & test
         run: |
-          nix-shell --pure --run '
+          nix-shell --pure --keep GITHUB_REPOSITORY --run '
             set -euo pipefail
             dirs=(
               .

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -25,25 +25,7 @@ jobs:
           EOF
       - name: Build & test
         run: |
-          nix-shell --pure --keep GITHUB_REPOSITORY --run '
-            set -euo pipefail
-            dirs=(
-              .
-              core
-              toolchains/go
-              toolchains/java
-              toolchains/cc
-              toolchains/python
-              toolchains/posix
-              toolchains/rust
-            )
-            for dir in "${dirs[@]}"
-            do
-              pushd $dir
-                bazel test //...
-              popd
-            done
-          '
+          nix-shell --pure --keep GITHUB_REPOSITORY --run 'bash .github/build-and-test'
   test-examples:
     name: Build & Test - Examples
     strategy:


### PR DESCRIPTION
After splitting the repository in multiple modules (in https://github.com/tweag/rules_nixpkgs/pull/193) tests are only run until the first error.

In case Bazel crashes due to build stream errors, this does not indicate a problem at our end. However, we should ensure that all tests passed to make an informed decision whether we can merge a PR even if the CI is not green.

----

Maybe, (just maybe) this also seems to have fixed the BuildBuddy crash issue -- all tests ran fine and there are now 10 tests reported at https://app.buildbuddy.io/history/repo/tweag/rules_nixpkgs