### PR TITLE
Avoid error when include dirs list is empty

### DIFF
--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -133,7 +133,7 @@ pkgs.runCommand "bazel-nixpkgs-cc-toolchain"
       $cc -E -x "$1" - -v "''${@:2}" 2>&1 \
         | sed -e '1,/^#include <...>/d;/^[^ ]/,$d;s/^ *//' -e 's: (framework directory)::g' \
         | tr '\n' '\0' \
-        | xargs -0 realpath -ms
+        | xargs -0 -r realpath -ms
     }
     CXX_BUILTIN_INCLUDE_DIRECTORIES=($({
       include_dirs_for c


### PR DESCRIPTION
Originally raised by @dmadisetti in #220.

This PR just skips running the `xargs` command if there are no arguments read from stdin.
