### PR TITLE
Update used Bazel version to 5

### DIFF
--- a/.bazelrc.ci
+++ b/.bazelrc.ci
@@ -13,6 +13,9 @@ build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
 build:ci --bes_backend=grpcs://remote.buildbuddy.io
 build:ci --remote_cache=grpcs://remote.buildbuddy.io
 build:ci --remote_timeout=3600
+build:ci --experimental_remote_cache_compression
+build:ci --experimental_remote_cache_async
+build:ci --remote_download_toplevel
 # Avoid failures of the form `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED`.
 # See https://github.com/tweag/rules_haskell/issues/1498.
 build:ci --keep_backend_build_event_connections_alive=false

--- a/.bazelrc.ci
+++ b/.bazelrc.ci
@@ -1,0 +1,18 @@
+# CI Configuration
+# ----------------
+# This will be activated by the CI runner.
+# Add `import %workspace%/.bazelrc.ci` to your `.bazelrc.local` and set
+# `--config ci` to test this configuration locally.
+
+common:ci --color=no
+build:ci --verbose_failures
+test:ci --test_output=errors
+
+# Use a remote cache during CI
+build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
+build:ci --bes_backend=grpcs://remote.buildbuddy.io
+build:ci --remote_cache=grpcs://remote.buildbuddy.io
+build:ci --remote_timeout=3600
+# Avoid failures of the form `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED`.
+# See https://github.com/tweag/rules_haskell/issues/1498.
+build:ci --keep_backend_build_event_connections_alive=false

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,5 +1,5 @@
 name: Continuous integration
-on: [push, pull_request]
+on: push
 jobs:
   test-nixpkgs:
     name: Build & Test - Nixpkgs

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -15,14 +15,14 @@ jobs:
       - uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=./core/nixpkgs.nix
-      - name: Configure
-        env:
-          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
-        run: |
-          cat >.bazelrc.local <<EOF
-          common --config=ci
-          build --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
-          EOF
+      # - name: Configure
+      #   env:
+      #     BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+      #   run: |
+      #     cat >.bazelrc.local <<EOF
+      #     common --config=ci
+      #     build --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
+      #     EOF
       - name: Build & test
         run: |
           nix-shell --pure --keep GITHUB_REPOSITORY --run 'bash .github/build-and-test'

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -19,9 +19,11 @@ jobs:
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
-          cat >.bazelrc.local <<EOF
+          cat >$HOME/.bazelrc <<EOF
           common --config=ci
           build --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
+          # no-op flag to avoid "ERROR: Config value 'ci' is not defined in any .rc file"
+          common:ci --announce_rc=false
           EOF
       - name: Build & test
         run: |
@@ -44,9 +46,11 @@ jobs:
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
-          cat >.bazelrc.local <<EOF
+          cat >$HOME/.bazelrc <<EOF
           common --config=ci
           build --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
+          # no-op flag to avoid "ERROR: Config value 'ci' is not defined in any .rc file"
+          common:ci --announce_rc=false
           EOF
       - name: Build & test
         run: |

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -15,14 +15,14 @@ jobs:
       - uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=./core/nixpkgs.nix
-      # - name: Configure
-      #   env:
-      #     BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
-      #   run: |
-      #     cat >.bazelrc.local <<EOF
-      #     common --config=ci
-      #     build --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
-      #     EOF
+      - name: Configure
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          cat >.bazelrc.local <<EOF
+          common --config=ci
+          build --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
+          EOF
       - name: Build & test
         run: |
           nix-shell --pure --keep GITHUB_REPOSITORY --run 'bash .github/build-and-test'

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -19,7 +19,8 @@ jobs:
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
-          cat >$HOME/.bazelrc <<EOF
+          cp .bazelrc.ci $HOME/.bazelrc
+          cat >>$HOME/.bazelrc <<EOF
           common --config=ci
           build --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
           # no-op flag to avoid "ERROR: Config value 'ci' is not defined in any .rc file"
@@ -46,7 +47,8 @@ jobs:
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
-          cat >$HOME/.bazelrc <<EOF
+          cp .bazelrc.ci $HOME/.bazelrc
+          cat >>$HOME/.bazelrc <<EOF
           common --config=ci
           build --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
           # no-op flag to avoid "ERROR: Config value 'ci' is not defined in any .rc file"

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ nixpkgs_package(
 ### nixpkgs_git_repository
 
 <pre>
-nixpkgs_git_repository(<a href="#nixpkgs_git_repository-name">name</a>, <a href="#nixpkgs_git_repository-remote">remote</a>, <a href="#nixpkgs_git_repository-revision">revision</a>, <a href="#nixpkgs_git_repository-sha256">sha256</a>)
+nixpkgs_git_repository(<a href="#nixpkgs_git_repository-name">name</a>, <a href="#nixpkgs_git_repository-remote">remote</a>, <a href="#nixpkgs_git_repository-repo_mapping">repo_mapping</a>, <a href="#nixpkgs_git_repository-revision">revision</a>, <a href="#nixpkgs_git_repository-sha256">sha256</a>)
 </pre>
 
 Name a specific revision of Nixpkgs on GitHub or a local checkout.
@@ -156,6 +156,19 @@ The URI of the remote Git repository. This must be a HTTP URL. There is currentl
 </p>
 </td>
 </tr>
+<tr id="nixpkgs_git_repository-repo_mapping">
+<td><code>repo_mapping</code></td>
+<td>
+
+<a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a>; required
+
+<p>
+
+A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<p>For example, an entry `"@foo": "@bar"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).
+
+</p>
+</td>
+</tr>
 <tr id="nixpkgs_git_repository-revision">
 <td><code>revision</code></td>
 <td>
@@ -191,7 +204,7 @@ The SHA256 used to verify the integrity of the repository.
 ### nixpkgs_local_repository
 
 <pre>
-nixpkgs_local_repository(<a href="#nixpkgs_local_repository-name">name</a>, <a href="#nixpkgs_local_repository-nix_file">nix_file</a>, <a href="#nixpkgs_local_repository-nix_file_content">nix_file_content</a>, <a href="#nixpkgs_local_repository-nix_file_deps">nix_file_deps</a>)
+nixpkgs_local_repository(<a href="#nixpkgs_local_repository-name">name</a>, <a href="#nixpkgs_local_repository-nix_file">nix_file</a>, <a href="#nixpkgs_local_repository-nix_file_content">nix_file_content</a>, <a href="#nixpkgs_local_repository-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_local_repository-repo_mapping">repo_mapping</a>)
 </pre>
 
 Create an external repository representing the content of Nixpkgs, based on a Nix expression stored locally or provided inline. One of `nix_file` or `nix_file_content` must be provided.
@@ -253,6 +266,19 @@ An expression for a Nix derivation.
 <p>
 
 Dependencies of `nix_file` if any.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_local_repository-repo_mapping">
+<td><code>repo_mapping</code></td>
+<td>
+
+<a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a>; required
+
+<p>
+
+A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<p>For example, an entry `"@foo": "@bar"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).
 
 </p>
 </td>
@@ -551,7 +577,7 @@ default is <code>None</code>
 <p>
 
 A repository label identifying which Nixpkgs to use.
-  Equivalent to `repositories = { "nixpkgs": ...}`.
+Equivalent to `repositories = { "nixpkgs": ...}`.
 
 </p>
 </td>
@@ -567,13 +593,13 @@ default is <code>{}</code>
 
 A dictionary mapping `NIX_PATH` entries to repository labels.
 
-  Setting it to
-  ```
-  repositories = { "myrepo" : "//:myrepo" }
-  ```
-  for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) for more information.
+Setting it to
+```
+repositories = { "myrepo" : "//:myrepo" }
+```
+for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) for more information.
 
-  Specify one of `repository` or `repositories`.
+Specify one of `repository` or `repositories`.
 
 </p>
 </td>
@@ -588,9 +614,9 @@ default is <code>None</code>
 <p>
 
 An expression for a Nix environment derivation.
-  The environment should expose all the commands that make up a CC
-  toolchain (`cc`, `ld` etc). Exposes all commands in `stdenv.cc` and
-  `binutils` by default.
+The environment should expose all the commands that make up a CC
+toolchain (`cc`, `ld` etc). Exposes all commands in `stdenv.cc` and
+`binutils` by default.
 
 </p>
 </td>
@@ -1056,13 +1082,13 @@ default is <code>{}</code>
 
 A dictionary mapping `NIX_PATH` entries to repository labels.
 
-  Setting it to
-  ```
-  repositories = { "myrepo" : "//:myrepo" }
-  ```
-  for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) for more information.
+Setting it to
+```
+repositories = { "myrepo" : "//:myrepo" }
+```
+for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) for more information.
 
-  Specify one of `repository` or `repositories`.
+Specify one of `repository` or `repositories`.
 
 </p>
 </td>
@@ -1078,28 +1104,28 @@ default is <code>None</code>
 
 The file to use as the BUILD file for this repository.
 
-  Its contents are copied copied into the file `BUILD` in root of the nix output folder. The Label does not need to be named `BUILD`, but can be.
+Its contents are copied copied into the file `BUILD` in root of the nix output folder. The Label does not need to be named `BUILD`, but can be.
 
-  For common use cases we provide filegroups that expose certain files as targets:
+For common use cases we provide filegroups that expose certain files as targets:
 
-  <dl>
-    <dt><code>:bin</code></dt>
-    <dd>Everything in the <code>bin/</code> directory.</dd>
-    <dt><code>:lib</code></dt>
-    <dd>All <code>.so</code> and <code>.a</code> files that can be found in subdirectories of <code>lib/</code>.</dd>
-    <dt><code>:include</code></dt>
-    <dd>All <code>.h</code> files that can be found in subdirectories of <code>bin/</code>.</dd>
-  </dl>
+<dl>
+  <dt><code>:bin</code></dt>
+  <dd>Everything in the <code>bin/</code> directory.</dd>
+  <dt><code>:lib</code></dt>
+  <dd>All <code>.so</code> and <code>.a</code> files that can be found in subdirectories of <code>lib/</code>.</dd>
+  <dt><code>:include</code></dt>
+  <dd>All <code>.h</code> files that can be found in subdirectories of <code>bin/</code>.</dd>
+</dl>
 
-  If you need different files from the nix package, you can reference them like this:
-  ```
-  package(default_visibility = [ "//visibility:public" ])
-  filegroup(
-      name = "our-docs",
-      srcs = glob(["share/doc/ourpackage/**/*"]),
-  )
-  ```
-  See the bazel documentation of [`filegroup`](https://docs.bazel.build/versions/master/be/general.html#filegroup) and [`glob`](https://docs.bazel.build/versions/master/be/functions.html#glob).
+If you need different files from the nix package, you can reference them like this:
+```
+package(default_visibility = [ "//visibility:public" ])
+filegroup(
+    name = "our-docs",
+    srcs = glob(["share/doc/ourpackage/**/*"]),
+)
+```
+See the bazel documentation of [`filegroup`](https://docs.bazel.build/versions/master/be/general.html#filegroup) and [`glob`](https://docs.bazel.build/versions/master/be/functions.html#glob).
 
 </p>
 </td>

--- a/core/.bazelrc
+++ b/core/.bazelrc
@@ -12,21 +12,6 @@ build --java_language_version=11
 build --tool_java_runtime_version=nixpkgs_java_11
 build --tool_java_language_version=11
 
-# CI Configuration
-# ----------------
-common:ci --color=no
-build:ci --verbose_failures
-test:ci --test_output=errors
-
-# Use a remote cache during CI
-build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
-build:ci --bes_backend=grpcs://remote.buildbuddy.io
-build:ci --remote_cache=grpcs://remote.buildbuddy.io
-build:ci --remote_timeout=3600
-# Avoid failures of the form `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED`.
-# See https://github.com/tweag/rules_haskell/issues/1498.
-build:ci --keep_backend_build_event_connections_alive=false
-
 # User Configuration
 # ------------------
 try-import %workspace%/.bazelrc.local

--- a/core/.bazelrc
+++ b/core/.bazelrc
@@ -7,10 +7,10 @@ build --crosstool_top=@nixpkgs_config_cc//:toolchain
 # recommended for `nixpkgs_cc_configure_hermetic`.
 # build --incompatible_enable_cc_toolchain_resolution
 
-build --javabase=@nixpkgs_java_runtime//:runtime
-build --host_javabase=@nixpkgs_java_runtime//:runtime
-build --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build --java_runtime_version=nixpkgs_java_11
+build --java_language_version=11
+build --tool_java_runtime_version=nixpkgs_java_11
+build --tool_java_language_version=11
 
 # CI Configuration
 # ----------------

--- a/core/.bazelrc
+++ b/core/.bazelrc
@@ -19,13 +19,13 @@ build:ci --verbose_failures
 test:ci --test_output=errors
 
 # Use a remote cache during CI
-build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
-build:ci --bes_backend=grpcs://remote.buildbuddy.io
-build:ci --remote_cache=grpcs://remote.buildbuddy.io
-build:ci --remote_timeout=3600
+# build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
+# build:ci --bes_backend=grpcs://remote.buildbuddy.io
+# build:ci --remote_cache=grpcs://remote.buildbuddy.io
+# build:ci --remote_timeout=3600
 # Avoid failures of the form `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED`.
 # See https://github.com/tweag/rules_haskell/issues/1498.
-build:ci --keep_backend_build_event_connections_alive=false
+# build:ci --keep_backend_build_event_connections_alive=false
 
 # User Configuration
 # ------------------

--- a/core/.bazelrc
+++ b/core/.bazelrc
@@ -19,13 +19,13 @@ build:ci --verbose_failures
 test:ci --test_output=errors
 
 # Use a remote cache during CI
-# build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
-# build:ci --bes_backend=grpcs://remote.buildbuddy.io
-# build:ci --remote_cache=grpcs://remote.buildbuddy.io
-# build:ci --remote_timeout=3600
+build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
+build:ci --bes_backend=grpcs://remote.buildbuddy.io
+build:ci --remote_cache=grpcs://remote.buildbuddy.io
+build:ci --remote_timeout=3600
 # Avoid failures of the form `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED`.
 # See https://github.com/tweag/rules_haskell/issues/1498.
-# build:ci --keep_backend_build_event_connections_alive=false
+build:ci --keep_backend_build_event_connections_alive=false
 
 # User Configuration
 # ------------------

--- a/core/WORKSPACE
+++ b/core/WORKSPACE
@@ -37,14 +37,8 @@ bazel_skylib_workspace()
 nixpkgs_git_repository(
     name = "remote_nixpkgs",
     remote = "https://github.com/NixOS/nixpkgs",
-    revision = "21.11",
-    sha256 = "c77bb41cf5dd82f4718fa789d49363f512bb6fa6bc25f8d60902fe2d698ed7cc",
-)
-
-nixpkgs_local_repository(
-    name = "nixpkgs",
-    nix_file = "//:nixpkgs.nix",
-    nix_file_deps = ["//:nixpkgs.json"],
+    revision = "22.05",
+    sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
 )
 
 # same as @nixpkgs but using the `nix_file_content` parameter

--- a/core/docs/dependencies_1.bzl
+++ b/core/docs/dependencies_1.bzl
@@ -13,18 +13,18 @@ def docs_dependencies_1():
     """
     maybe(
         http_archive,
-        "io_bazel_stardoc",
-        sha256 = "6d07d18c15abb0f6d393adbd6075cd661a2219faab56a9517741f0fc755f6f3c",
-        strip_prefix = "stardoc-0.4.0",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/stardoc/archive/0.4.0.tar.gz",
-            "https://github.com/bazelbuild/stardoc/archive/0.4.0.tar.gz",
-        ],
-    )
-    maybe(
-        http_archive,
         "rules_sh",
         sha256 = "83a065ba6469135a35786eb741e17d50f360ca92ab2897857475ab17c0d29931",
         strip_prefix = "rules_sh-0.2.0",
         urls = ["https://github.com/tweag/rules_sh/archive/v0.2.0.tar.gz"],
+    )
+
+    maybe(
+        http_archive,
+        "io_bazel_stardoc",
+        sha256 = "aa814dae0ac400bbab2e8881f9915c6f47c49664bf087c409a15f90438d2c23e",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.1/stardoc-0.5.1.tar.gz",
+            "https://github.com/bazelbuild/stardoc/releases/download/0.5.1/stardoc-0.5.1.tar.gz",
+        ],
     )

--- a/core/docs/dependencies_2.bzl
+++ b/core/docs/dependencies_2.bzl
@@ -4,23 +4,25 @@
 # this has to be split into `docs_dependencies_1` and `docs_dependencies_2`
 # because Bazel is imperative, and requires `load()` to be a top-level
 # statement.
-load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
-load("@rules_java//java:repositories.bzl", "rules_java_dependencies")
+load("@rules_nixpkgs_core//:nixpkgs.bzl", "nixpkgs_local_repository")
 load("@rules_sh//sh:repositories.bzl", "rules_sh_dependencies")
 load("@rules_sh//sh:posix.bzl", "sh_posix_configure")
-load("@rules_nixpkgs_core//:nixpkgs.bzl", "nixpkgs_local_repository")
-load("@rules_nixpkgs_cc//:cc.bzl", "nixpkgs_cc_configure")
-load("@rules_nixpkgs_java//:java.bzl", "nixpkgs_java_configure")
 load("@rules_nixpkgs_posix//:posix.bzl", "nixpkgs_sh_posix_configure")
+load("@rules_nixpkgs_cc//:cc.bzl", "nixpkgs_cc_configure")
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_java_configure")
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 def docs_dependencies_2():
-    stardoc_repositories()
-
     nixpkgs_local_repository(
         name = "nixpkgs",
         nix_file = "@rules_nixpkgs_core//:nixpkgs.nix",
         nix_file_deps = ["@rules_nixpkgs_core//:nixpkgs.json"],
     )
+
+    rules_sh_dependencies()
+    nixpkgs_sh_posix_configure(repository = "@nixpkgs")
+    sh_posix_configure()
 
     nixpkgs_cc_configure(
         name = "nixpkgs_config_cc",
@@ -30,12 +32,13 @@ def docs_dependencies_2():
     rules_java_dependencies()
 
     nixpkgs_java_configure(
-        attribute_path = "jdk8.home",
+        attribute_path = "jdk11.home",
         repository = "@nixpkgs",
+        toolchain = True,
+        toolchain_name = "nixpkgs_java",
+        toolchain_version = "11",
     )
 
-    rules_sh_dependencies()
+    rules_java_toolchains()
 
-    nixpkgs_sh_posix_configure(repository = "@nixpkgs")
-
-    sh_posix_configure()
+    stardoc_repositories()

--- a/core/nixpkgs.json
+++ b/core/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "branch": "nixpkgs-unstable",
-  "rev": "506445d88e183bce80e47fc612c710eb592045ed",
-  "sha256": "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02"
+  "branch": "22.05",
+  "rev": "ce6aa13369b667ac2542593170993504932eb836",
+  "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik"
 }

--- a/examples/python-container/README.md
+++ b/examples/python-container/README.md
@@ -55,7 +55,7 @@ create a file `shell.nix` wit the following content:
 
 pkgs.mkShell {
     nativeBuildInputs = [
-       pkgs.bazel_4
+       pkgs.bazel_5
     ];
 }
 ```
@@ -98,12 +98,12 @@ http_archive(
 load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
 rules_nixpkgs_dependencies()
 
-# Define nixpkgs version 21.11
+# Define nixpkgs version 22.05
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository")
 nixpkgs_git_repository(
     name = "nixpkgs",
-    revision = "21.11",
-    sha256 = "c77bb41cf5dd82f4718fa789d49363f512bb6fa6bc25f8d60902fe2d698ed7cc",
+    revision = "22.05",
+    sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
 )
 
 # Configure python

--- a/examples/python-container/WORKSPACE
+++ b/examples/python-container/WORKSPACE
@@ -18,8 +18,8 @@ rules_nixpkgs_dependencies()
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository")
 nixpkgs_git_repository(
     name = "nixpkgs",
-    revision = "21.11",
-    sha256 = "c77bb41cf5dd82f4718fa789d49363f512bb6fa6bc25f8d60902fe2d698ed7cc",
+    revision = "22.05",
+    sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
 )
 
 # Configure python

--- a/examples/python-container/shell.nix
+++ b/examples/python-container/shell.nix
@@ -2,7 +2,7 @@
 
 pkgs.mkShell {
     nativeBuildInputs = [
-       pkgs.bazel_4
+       pkgs.bazel_5
     ];
 }
 

--- a/examples/toolchains/cc/WORKSPACE
+++ b/examples/toolchains/cc/WORKSPACE
@@ -26,8 +26,8 @@ load(
 
 nixpkgs_git_repository(
     name = "nixpkgs",
-    revision = "21.11",
-    sha256 = "c77bb41cf5dd82f4718fa789d49363f512bb6fa6bc25f8d60902fe2d698ed7cc",
+    revision = "22.05",
+    sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
 )
 
 nixpkgs_cc_configure(

--- a/examples/toolchains/cc/nixpkgs.json
+++ b/examples/toolchains/cc/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "branch": "21.11",
-  "rev": "506445d88e183bce80e47fc612c710eb592045ed",
-  "sha256": "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02"
+  "branch": "22.05",
+  "rev": "ce6aa13369b667ac2542593170993504932eb836",
+  "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik"
 }

--- a/examples/toolchains/cc/shell.nix
+++ b/examples/toolchains/cc/shell.nix
@@ -1,3 +1,3 @@
 { pkgs ? import ./nixpkgs.nix { } }:
 
-pkgs.mkShell { nativeBuildInputs = [ pkgs.bazel_4 ]; }
+pkgs.mkShell { nativeBuildInputs = [ pkgs.bazel_5 ]; }

--- a/examples/toolchains/cc_with_deps/WORKSPACE
+++ b/examples/toolchains/cc_with_deps/WORKSPACE
@@ -16,8 +16,8 @@ load(
 
 nixpkgs_git_repository(
     name = "nixpkgs",
-    revision = "21.11",
-    sha256 = "c77bb41cf5dd82f4718fa789d49363f512bb6fa6bc25f8d60902fe2d698ed7cc",
+    revision = "22.05",
+    sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
 )
 
 nixpkgs_cc_configure(

--- a/examples/toolchains/cc_with_deps/nixpkgs.json
+++ b/examples/toolchains/cc_with_deps/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "branch": "21.11",
-  "rev": "506445d88e183bce80e47fc612c710eb592045ed",
-  "sha256": "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02"
+  "branch": "22.05",
+  "rev": "ce6aa13369b667ac2542593170993504932eb836",
+  "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik"
 }

--- a/examples/toolchains/cc_with_deps/shell.nix
+++ b/examples/toolchains/cc_with_deps/shell.nix
@@ -1,3 +1,3 @@
 { pkgs ? import ./nixpkgs.nix { } }:
 
-pkgs.mkShell { nativeBuildInputs = [ pkgs.bazel_4 ]; }
+pkgs.mkShell { nativeBuildInputs = [ pkgs.bazel_5 ]; }

--- a/examples/toolchains/go/WORKSPACE
+++ b/examples/toolchains/go/WORKSPACE
@@ -27,8 +27,8 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository")
 
 nixpkgs_git_repository(
     name = "nixpkgs",
-    revision = "21.11",
-    sha256 = "c77bb41cf5dd82f4718fa789d49363f512bb6fa6bc25f8d60902fe2d698ed7cc",
+    revision = "22.05",
+    sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/go.bzl", "nixpkgs_go_configure")

--- a/examples/toolchains/go/nixpkgs.json
+++ b/examples/toolchains/go/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "branch": "21.11",
-  "rev": "506445d88e183bce80e47fc612c710eb592045ed",
-  "sha256": "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02"
+  "branch": "22.05",
+  "rev": "ce6aa13369b667ac2542593170993504932eb836",
+  "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik"
 }

--- a/examples/toolchains/go/shell.nix
+++ b/examples/toolchains/go/shell.nix
@@ -1,3 +1,3 @@
 { pkgs ? import ./nixpkgs.nix { } }:
 
-pkgs.mkShell { nativeBuildInputs = [ pkgs.bazel_4 ]; }
+pkgs.mkShell { nativeBuildInputs = [ pkgs.bazel_5 ]; }

--- a/examples/toolchains/java/WORKSPACE
+++ b/examples/toolchains/java/WORKSPACE
@@ -25,8 +25,8 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository")
 
 nixpkgs_git_repository(
     name = "nixpkgs",
-    revision = "21.11",
-    sha256 = "c77bb41cf5dd82f4718fa789d49363f512bb6fa6bc25f8d60902fe2d698ed7cc",
+    revision = "22.05",
+    sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_java_configure")

--- a/examples/toolchains/java/nixpkgs.json
+++ b/examples/toolchains/java/nixpkgs.json
@@ -1,8 +1,8 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "branch": "unstable",
-  "rev": "7f9b6e2babf232412682c09e57ed666d8f84ac2d",
-  "sha256": "03nb8sbzgc3c0qdr1jbsn852zi3qp74z4qcy7vrabvvly8rbixp2"
+  "branch": "22.05",
+  "rev": "ce6aa13369b667ac2542593170993504932eb836",
+  "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik"
 }
 

--- a/examples/toolchains/python/WORKSPACE
+++ b/examples/toolchains/python/WORKSPACE
@@ -13,8 +13,8 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository")
 
 nixpkgs_git_repository(
     name = "nixpkgs",
-    revision = "21.11",
-    sha256 = "c77bb41cf5dd82f4718fa789d49363f512bb6fa6bc25f8d60902fe2d698ed7cc",
+    revision = "22.05",
+    sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_python_configure")

--- a/examples/toolchains/python/nixpkgs.json
+++ b/examples/toolchains/python/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "branch": "21.11",
-  "rev": "506445d88e183bce80e47fc612c710eb592045ed",
-  "sha256": "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02"
+  "branch": "22.05",
+  "rev": "ce6aa13369b667ac2542593170993504932eb836",
+  "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik"
 }

--- a/examples/toolchains/python/shell.nix
+++ b/examples/toolchains/python/shell.nix
@@ -1,3 +1,3 @@
 { pkgs ? import ./nixpkgs.nix { } }:
 
-pkgs.mkShell { nativeBuildInputs = [ pkgs.bazel_4 ]; }
+pkgs.mkShell { nativeBuildInputs = [ pkgs.bazel_5 ]; }

--- a/examples/toolchains/rust/WORKSPACE
+++ b/examples/toolchains/rust/WORKSPACE
@@ -24,8 +24,8 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository")
 
 nixpkgs_git_repository(
     name = "nixpkgs",
-    revision = "21.11",
-    sha256 = "c77bb41cf5dd82f4718fa789d49363f512bb6fa6bc25f8d60902fe2d698ed7cc",
+    revision = "22.05",
+    sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
 )
 
 # rules_rust also uses the cc compiler

--- a/examples/toolchains/rust/nixpkgs.json
+++ b/examples/toolchains/rust/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "branch": "21.11",
-  "rev": "506445d88e183bce80e47fc612c710eb592045ed",
-  "sha256": "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02"
+  "branch": "22.05",
+  "rev": "ce6aa13369b667ac2542593170993504932eb836",
+  "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik"
 }

--- a/examples/toolchains/rust/shell.nix
+++ b/examples/toolchains/rust/shell.nix
@@ -1,3 +1,3 @@
 { pkgs ? import ./nixpkgs.nix { } }:
 
-pkgs.mkShell { nativeBuildInputs = [ pkgs.bazel_4 ]; }
+pkgs.mkShell { nativeBuildInputs = [ pkgs.bazel_5 ]; }

--- a/nixpkgs/repositories.bzl
+++ b/nixpkgs/repositories.bzl
@@ -29,8 +29,9 @@ def rules_nixpkgs_dependencies(rules_nixpkgs_name = "io_tweag_rules_nixpkgs"):
     maybe(
         http_archive,
         "rules_java",
-        url = "https://github.com/bazelbuild/rules_java/releases/download/4.0.0/rules_java-4.0.0.tar.gz",
-        sha256 = "34b41ec683e67253043ab1a3d1e8b7c61e4e8edefbcad485381328c934d072fe",
+        sha256 = "ddc9e11f4836265fea905d2845ac1d04ebad12a255f791ef7fd648d1d2215a5b",
+        strip_prefix = "rules_java-5.0.0",
+        url = "https://github.com/bazelbuild/rules_java/archive/refs/tags/5.0.0.tar.gz",
     )
 
     # the following complication is due to migrating to `bzlmod`.

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@ with pkgs;
 
 mkShell {
   buildInputs = [
-    bazel_4
+    bazel_5
     cacert
     gcc
     nix

--- a/toolchains/go/README.md
+++ b/toolchains/go/README.md
@@ -136,13 +136,13 @@ default is <code>{}</code>
 
 A dictionary mapping `NIX_PATH` entries to repository labels.
 
-  Setting it to
-  ```
-  repositories = { "myrepo" : "//:myrepo" }
-  ```
-  for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) for more information.
+Setting it to
+```
+repositories = { "myrepo" : "//:myrepo" }
+```
+for example would replace all instances of `<myrepo>` in the called nix code by the path to the target `"//:myrepo"`. See the [relevant section in the nix manual](https://nixos.org/nix/manual/#env-NIX_PATH) for more information.
 
-  Specify one of `path` or `repositories`.
+Specify one of `path` or `repositories`.
 
 </p>
 </td>

--- a/toolchains/java/tests/java-test.bzl
+++ b/toolchains/java/tests/java-test.bzl
@@ -3,9 +3,10 @@ load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 def _java_runtime_test_impl(ctx):
     env = unittest.begin(ctx)
 
-    nixpkgs_java_runtime = ctx.attr._nixpkgs_java_runtime[platform_common.ToolchainInfo]
+    nixpkgs_java_runtime = ctx.attr._nixpkgs_java_runtime[platform_common.ToolchainInfo].java_runtime
 
     java_runtime = ctx.attr._java_runtime[java_common.JavaRuntimeInfo]
+
     asserts.equals(
         env,
         expected = nixpkgs_java_runtime.java_home,


### PR DESCRIPTION
This pull requests will:
* Ensure all invocations are using Bazel version >= 5.0.0
* Ensure all references to nixpkgs will use channel 22.05
* Ensure rules_java are using java toolchains
* Update used version of openJDK to 11
* Update io_bazel_startdoc to version 0.5.1 (required for Bazel 5 compatibility)
* Update rules_java to version 5.0.0 (required for Bazel 5 compatibility)
* Update README.md's