### PR TITLE
refactor: Move packages from buildInputs to packages

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,13 +1,8 @@
-{ pkgs ? import ./core/nixpkgs.nix { config = {}; overlays = []; } }:
+{ pkgs ? import ./core/nixpkgs.nix { } }:
 
 with pkgs;
 
 mkShell {
-  buildInputs = [
-    bazel_5
-    cacert
-    gcc
-    nix
-    git
-  ];
+  name = "rules_nixpkgs_shell";
+  packages = [ bazel_5 bazel-buildtools cacert gcc nix git ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,7 @@
-{ pkgs ? import ./core/nixpkgs.nix { } }:
+{ pkgs ? import ./core/nixpkgs.nix {
+  config = { };
+  overlays = [ ];
+} }:
 
 with pkgs;
 


### PR DESCRIPTION
Packages like `bazel_5` should reside in `packages` instead of
`buildInputs`. Since the former will cause the shell completion scripts
to be installed as well. Meaning we can actually use `bazel <TAB>` to
complete things :).