### PR TITLE
Fix clang runtime profiling library not found error on Darwin

### DIFF
--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -27,8 +27,8 @@ let
     # Work around https://github.com/NixOS/nixpkgs/issues/42059.
     # See also https://github.com/NixOS/nixpkgs/pull/41589.
     pkgs.wrapCCWith rec {
-      cc = pkgs.stdenv.cc;
-      bintools = cc.bintools.override { inherit postLinkSignHook; };
+      cc = pkgs.stdenv.cc.cc;
+      bintools = pkgs.stdenv.cc.bintools.override { inherit postLinkSignHook; };
       extraBuildCommands = with pkgs.darwin.apple_sdk.frameworks; ''
         echo "-Wno-unused-command-line-argument" >> $out/nix-support/cc-cflags
         echo "-isystem ${pkgs.llvmPackages.libcxx.dev}/include/c++/v1" >> $out/nix-support/cc-cflags
@@ -41,12 +41,6 @@ let
         echo "-L${pkgs.llvmPackages.libcxxabi}/lib" >> $out/nix-support/cc-cflags
         echo "-L${pkgs.libiconv}/lib" >> $out/nix-support/cc-cflags
         echo "-L${pkgs.darwin.libobjc}/lib" >> $out/nix-support/cc-cflags
-
-        # avoid linker warning about non-existent directory
-        # > ld: warning: directory not found for option '-L/nix/store/gsfxxazc51sx6vjdrz6cq8s19x7h5mwh-clang-wrapper-7.1.0/lib'
-        if ! [[ -d '${pkgs.lib.getLib cc}/lib' ]]; then
-          sed -i -e 's%-L${pkgs.lib.getLib cc}/lib\($\| \)%%' $out/nix-support/cc-ldflags
-        fi
       '';
     };
   cc =

--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -41,6 +41,7 @@ let
         echo "-L${pkgs.llvmPackages.libcxxabi}/lib" >> $out/nix-support/cc-cflags
         echo "-L${pkgs.libiconv}/lib" >> $out/nix-support/cc-cflags
         echo "-L${pkgs.darwin.libobjc}/lib" >> $out/nix-support/cc-cflags
+        echo "-resource-dir=${pkgs.stdenv.cc}/resource-root" >> $out/nix-support/cc-cflags
       '';
     };
   cc =


### PR DESCRIPTION
```
ERROR: /Users/runner/work/rules_haskell/rules_haskell/tests/two-same-file/BUILD.bazel:6:13: HaskellLinkBinary tests/two-same-file/one failed: (Exit 1): ghc_wrapper failed: error executing command
  (cd /private/var/tmp/_bazel_runner/d1e3bdaa0c37ce8d00ecff62b05849c3/sandbox/processwrapper-sandbox/4287/execroot/rules_haskell && \
  exec env - \
    CC_WRAPPER_CC_PATH=external/nixpkgs_config_cc/cc_wrapper.sh \
    CC_WRAPPER_CPU=darwin \
    CC_WRAPPER_PLATFORM=darwin \
    LANG=C.UTF-8 \
    RULES_HASKELL_DOCDIR_PATH=/nix/store/li6yc9c5ya7id1pwr71a1cgj7bah5lf7-ghc-8.10.7-doc/share/doc/ghc/html/libraries/base-4.14.3.0 \
    RULES_HASKELL_GHC_PATH=external/rules_haskell_ghc_nixpkgs/bin/ghc \
    RULES_HASKELL_GHC_PKG_PATH=external/rules_haskell_ghc_nixpkgs/bin/ghc-pkg \
    RULES_HASKELL_LIBDIR_PATH=/nix/store/4r3mqcs0qxpzv4pmzpwcqyafcs49y2mz-ghc-8.10.7/lib/ghc-8.10.7 \
  bazel-out/host/bin/haskell/ghc_wrapper bazel-out/darwin-fastbuild/bin/tests/two-same-file/compile_flags_one__HaskellLinkBinary bazel-out/darwin-fastbuild/bin/tests/two-same-file/extra_args_one__HaskellLinkBinary)
Execution platform: @rules_nixpkgs_core//platforms:host
Use --sandbox_debug to see verbose messages from the sandbox
ld: file not found: /nix/store/zfh3npfhfjjgwi0dqpriklip5k15ppmj-clang-7.1.0/lib/clang/7.1.0/lib/darwin/libclang_rt.profile_osx.a

```
This has been originally encountered here https://github.com/tweag/rules_haskell/issues/1768



