### PR TITLE
[PoC] Package up `binary` targets & dependencies in a nix package or docker container

### DIFF
--- a/core/nixpkgs.bzl
+++ b/core/nixpkgs.bzl
@@ -256,7 +256,7 @@ def _nixpkgs_package_impl(repository_ctx):
         )
         query_result = execute_or_fail(
             repository_ctx,
-            [nix_store, '-qd', out_link + '.drv'],
+            [nix_store_path, '-qd', out_link + '.drv'],
             failure_message = "Cannot query nix path '{}.drv'.".format(out_link),
             quiet = repository_ctx.attr.quiet,
             timeout = 1000,


### PR DESCRIPTION
Hello! I stumbled on nix and this repo a few days ago and really love the idea. Thanks so much for creating it. I can see so much potential here.

Anyways, I am trying to create a rule to package up a binary target into a docker container (with all of its nix dependencies) with bazel. e.g., in a `rule.bzl` file I have a command to generate a docker tar file:
```python
load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")

def nix_image(name, target, data, visibility=None):
  # TODO: still need to get runfiles in!
  native.genrule(
    name = 'gen_image_%s' % name,
    outs = [name + ".tar.gz"],
    cmd = r'''
# TODO: hacky -- want to take in the transitive deps explicitly!

# find the *derivers* for the outputs paths:
f=$$(find | grep bazel-support/nix-out-link.drv)
echo "Found derivers: $$f"
lines=$$(echo $$f | xargs realpath | paste -sd "," -)
echo nix-build $$(realpath $(location //nix:docker.nix)) --arg lines \"$$lines\" >&2
build_out=$$(nix-build $$(realpath $(location //nix:docker.nix)) --arg lines \"$$lines\")
echo out: $$build_out >&2
ln -s $$build_out $(OUTS)
''',
    tools=["//nix:docker.nix"] + data + [target],
    visibility = visibility,
  )
```

Notice the above (hackily) looks for any `bazel-support/nix-out-link.drv` in the build context and then passes them all to this derivation (in `//nix:docker.nix`):

```nix
{ pkgs ? import <nixpkgs> {}, lines ? "" }:
let
  x = break;
  imports = map (l: import l) (pkgs.lib.strings.splitString "," lines);
in
pkgs.dockerTools.buildImage {
    name = "test-nix";
    tag = "latest";

    copyToRoot = pkgs.buildEnv {
      name = "image-root";
      paths = [pkgs.coreutils pkgs.bashInteractive] ++ imports;
      pathsToLink = [ "/bin" "/lib" ];
    };
}
```

But to get the `.drv` files which are needed as inputs (I couldn't figure out how to `import` the built derivations as inputs), I had to create the changes in this PR.

I am wondering if there is a way to build an image like this without having to modify `rules_nixpkgs`? If not, what'd be the best way to support it?