### PR TITLE
Update bzlmod dependencies and enhance separation of components

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,10 +47,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "7c10271940c6bce577d51a075ae77728964db285dac0a46614a7934dc34303e6",
+    sha256 = "685052b498b6ddfe562ca7a97736741d87916fe536623afb7da2824c0211c369",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.26.0/rules_go-v0.26.0.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.26.0/rules_go-v0.26.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
     ],
 )
 

--- a/core/MODULE.bazel
+++ b/core/MODULE.bazel
@@ -4,4 +4,6 @@ module(
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "bazel_skylib", version = "1.0.3")
+bazel_dep(name = "bazel_skylib", version = "1.0.3", repo_name = "bazel_skylib")
+bazel_dep(name = "rules_sh", version = "0.3.0")
+bazel_dep(name = "stardoc", version = "0.5.1", repo_name = "io_bazel_stardoc")

--- a/core/WORKSPACE
+++ b/core/WORKSPACE
@@ -10,7 +10,7 @@ local_repository(
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
 
-rules_nixpkgs_dependencies()
+rules_nixpkgs_dependencies(toolchains = ['cc', 'java', 'posix'])
 
 load("@rules_nixpkgs_core//docs:dependencies_1.bzl", "docs_dependencies_1")
 

--- a/core/docs/dependencies_2.bzl
+++ b/core/docs/dependencies_2.bzl
@@ -5,12 +5,12 @@
 # because Bazel is imperative, and requires `load()` to be a top-level
 # statement.
 load("@rules_nixpkgs_core//:nixpkgs.bzl", "nixpkgs_local_repository")
+load("@rules_nixpkgs_java//:java.bzl", "nixpkgs_java_configure")
 load("@rules_sh//sh:repositories.bzl", "rules_sh_dependencies")
 load("@rules_sh//sh:posix.bzl", "sh_posix_configure")
 load("@rules_nixpkgs_posix//:posix.bzl", "nixpkgs_sh_posix_configure")
 load("@rules_nixpkgs_cc//:cc.bzl", "nixpkgs_cc_configure")
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
-load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_java_configure")
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 def docs_dependencies_2():

--- a/examples/toolchains/go/WORKSPACE
+++ b/examples/toolchains/go/WORKSPACE
@@ -8,10 +8,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f",
+    sha256 = "685052b498b6ddfe562ca7a97736741d87916fe536623afb7da2824c0211c369",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
     ],
 )
 

--- a/nixpkgs/repositories.bzl
+++ b/nixpkgs/repositories.bzl
@@ -2,11 +2,12 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-def rules_nixpkgs_dependencies(rules_nixpkgs_name = "io_tweag_rules_nixpkgs"):
+def rules_nixpkgs_dependencies(rules_nixpkgs_name = "io_tweag_rules_nixpkgs", toolchains = None):
     """Load repositories required by rules_nixpkgs.
 
     Args:
         rules_nixpkgs_name: name under which this repository is known in your workspace
+        toolchains:         list of toolchains to load, ['cc', 'java'], load all toolchains by default
     """
     maybe(
         http_archive,
@@ -50,14 +51,10 @@ def rules_nixpkgs_dependencies(rules_nixpkgs_name = "io_tweag_rules_nixpkgs"):
     if strip_prefix:
         strip_prefix += "/"
 
-    for name, prefix in [
-        ("rules_nixpkgs_core", "core"),
-        ("rules_nixpkgs_cc", "toolchains/cc"),
-        ("rules_nixpkgs_java", "toolchains/java"),
-        ("rules_nixpkgs_python", "toolchains/python"),
-        ("rules_nixpkgs_go", "toolchains/go"),
-        ("rules_nixpkgs_rust", "toolchains/rust"),
-        ("rules_nixpkgs_posix", "toolchains/posix"),
+    for name, prefix in [("rules_nixpkgs_core", "core")] + [
+        ("rules_nixpkgs_" + toolchain, "toolchains/" + toolchain)
+        for toolchain in [ 'cc', 'java', 'python', 'go', 'rust', 'posix' ]
+        if toolchains == None or toolchain in toolchains
     ]:
         # case analysis in inner loop to reduce code duplication
         if kind == "local_repository":

--- a/toolchains/cc/WORKSPACE
+++ b/toolchains/cc/WORKSPACE
@@ -10,7 +10,7 @@ local_repository(
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
 
-rules_nixpkgs_dependencies()
+rules_nixpkgs_dependencies(toolchains = ['cc', 'java', 'posix'])
 
 load("@rules_nixpkgs_core//docs:dependencies_1.bzl", "docs_dependencies_1")
 

--- a/toolchains/go/MODULE.bazel
+++ b/toolchains/go/MODULE.bazel
@@ -4,8 +4,4 @@ module(
 )
 
 bazel_dep(name = "rules_nixpkgs_core", version = "0.9.0")
-# TODO: there is no BCR entry for `rules_go` yet, and you will have to add a
-# local registry entry to map a commit to a module "version". the caller will
-# also have to know this and point `--registry` at the file from right revision
-# on GitHub!
-# bazel_dep(name = "rules_go", repo_name = "rules_go", version = "0.26.0")
+bazel_dep(name = "rules_go", repo_name = "rules_go", version = "0.33.0")

--- a/toolchains/go/WORKSPACE
+++ b/toolchains/go/WORKSPACE
@@ -26,10 +26,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "7c10271940c6bce577d51a075ae77728964db285dac0a46614a7934dc34303e6",
+    sha256 = "",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.26.0/rules_go-v0.26.0.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.26.0/rules_go-v0.26.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
     ],
 )
 

--- a/toolchains/go/WORKSPACE
+++ b/toolchains/go/WORKSPACE
@@ -10,7 +10,7 @@ local_repository(
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
 
-rules_nixpkgs_dependencies()
+rules_nixpkgs_dependencies(toolchains = ['cc', 'java', 'posix'])
 
 load("@rules_nixpkgs_core//docs:dependencies_1.bzl", "docs_dependencies_1")
 

--- a/toolchains/java/WORKSPACE
+++ b/toolchains/java/WORKSPACE
@@ -1,6 +1,8 @@
 # NOTE: temporary boilerplate for compatibility with `WORKSPACE` setup!
 # TODO: remove when migration to `bzlmod` is complete
 
+workspace(name = "rules_nixpkgs_java")
+
 ### generic dependencies for rendering documentation
 
 local_repository(

--- a/toolchains/java/WORKSPACE
+++ b/toolchains/java/WORKSPACE
@@ -10,7 +10,7 @@ local_repository(
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
 
-rules_nixpkgs_dependencies()
+rules_nixpkgs_dependencies(toolchains = ['cc', 'posix'])
 
 load("@rules_nixpkgs_core//docs:dependencies_1.bzl", "docs_dependencies_1")
 

--- a/toolchains/java/local_java_repository.bzl
+++ b/toolchains/java/local_java_repository.bzl
@@ -14,7 +14,7 @@
 
 """Rules for importing and registering a local JDK."""
 
-load("@rules_nixpkgs_java//:default_java_toolchain.bzl", "JVM8_TOOLCHAIN_CONFIGURATION", "default_java_toolchain")
+load(":default_java_toolchain.bzl", "JVM8_TOOLCHAIN_CONFIGURATION", "default_java_toolchain")
 
 def _detect_java_version(repository_ctx, java_bin):
     properties_out = repository_ctx.execute([java_bin, "-XshowSettings:properties"]).stderr

--- a/toolchains/python/WORKSPACE
+++ b/toolchains/python/WORKSPACE
@@ -10,7 +10,7 @@ local_repository(
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
 
-rules_nixpkgs_dependencies()
+rules_nixpkgs_dependencies(toolchains = ['cc', 'java', 'posix'])
 
 load("@rules_nixpkgs_core//docs:dependencies_1.bzl", "docs_dependencies_1")
 


### PR DESCRIPTION
This PR takes bzlmod migration a step further and tries to lay ground for future work in that area.

Currently, there are a few components / modules which were all depending on each other:

* `core`
* toolchains:
    * cc
    * go
    * java
    * posix
    * rust
    * python
* nixpkgs (the *everything* component)

It should be possible to require a specific toolchain with only pulling in the required dependencies.

This PR adds a `toolchains` parameter to the `rules_nixpkgs_dependencies` function signalling which toolchain is required. 

Interestingly, every component depends on java, posix and the cc toolchain (even the core). This is because of the stardoc dependency which consists of a `java_binary`...

IMO, it would be a good idea to separate the docs generation into another component, in order to get rid of the excess dependencies. WDYT?