### PR TITLE
Avoid restarting nixpkgs_package

### DIFF
--- a/core/nixpkgs.bzl
+++ b/core/nixpkgs.bzl
@@ -36,6 +36,7 @@ load(
     "executable_path",
     "execute_or_fail",
     "expand_location",
+    "external_repository_root",
     "find_children",
     "is_supported_platform",
 )
@@ -126,13 +127,6 @@ Create an external repository representing the content of Nixpkgs, based on a Ni
 """,
 )
 
-def _external_repository_root(label):
-    return "/".join([
-        component
-        for component in [label.workspace_root, label.package, label.name]
-        if component
-    ])
-
 def _nixpkgs_package_impl(repository_ctx):
     repository = repository_ctx.attr.repository
     repositories = repository_ctx.attr.repositories
@@ -179,11 +173,11 @@ def _nixpkgs_package_impl(repository_ctx):
 
     if repository_ctx.attr.nix_file:
         repository_ctx.path(repository_ctx.attr.nix_file)
-        repository_ctx.path(_external_repository_root(repository_ctx.attr.nix_file))
+        repository_ctx.path(external_repository_root(repository_ctx.attr.nix_file))
 
     for dep in repository_ctx.attr.nix_file_deps:
         repository_ctx.path(dep)
-        repository_ctx.path(_external_repository_root(dep))
+        repository_ctx.path(external_repository_root(dep))
 
     # Is nix supported on this platform?
     not_supported = not is_supported_platform(repository_ctx)

--- a/core/util.bzl
+++ b/core/util.bzl
@@ -25,6 +25,7 @@ def _is_executable(repository_ctx, path):
     return mode & 0o100 != 0
 
 def external_repository_root(label):
+    """Get path to repository root from label."""
     return "/".join([
         component
         for component in [label.workspace_root, label.package, label.name]
@@ -46,7 +47,7 @@ def cp(repository_ctx, src, dest = None):
     if dest == None:
         if type(src) != "Label":
             fail("src must be a Label if dest is not specified explicitly.")
-        dest = external_repository_root(label)
+        dest = external_repository_root(src)
 
     src_path = repository_ctx.path(src)
     dest_path = repository_ctx.path(dest)

--- a/core/util.bzl
+++ b/core/util.bzl
@@ -24,6 +24,13 @@ def _is_executable(repository_ctx, path):
     mode = int(stdout, 8)
     return mode & 0o100 != 0
 
+def external_repository_root(label):
+    return "/".join([
+        component
+        for component in [label.workspace_root, label.package, label.name]
+        if component
+    ])
+
 def cp(repository_ctx, src, dest = None):
     """Copy the given file into the external repository root.
 
@@ -39,11 +46,7 @@ def cp(repository_ctx, src, dest = None):
     if dest == None:
         if type(src) != "Label":
             fail("src must be a Label if dest is not specified explicitly.")
-        dest = "/".join([
-            component
-            for component in [src.workspace_root, src.package, src.name]
-            if component
-        ])
+        dest = external_repository_root(label)
 
     src_path = repository_ctx.path(src)
     dest_path = repository_ctx.path(dest)


### PR DESCRIPTION
TL;DR: pre-resolve all repository_ctx.path() before cp() calls.

See bazelbuild/bazel#4533 for background, repository rules in bazel will
be restarted if a depedency it requests is missing.

> When a Skyframe value is missing, fetching must be restarted, thus, in order to avoid doing duplicate work, it’s better to first request the Skyframe dependencies you need and only then start doing anything costly.
>
> https://github.com/bazelbuild/bazel/blob/0b485417a03b071038389609d0c66055db7ef636/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java#L150-L152

In the context of rules_nixpkgs, this can cause `nixpkgs_package` to be
restarted every time an additional label is referenced in the rule. This
is especially bad if the rule just happened to finish the slow `cp()`
calls and new labels are referred to after that.

As a workaround, we pre-resolve all labels at the top of repository_rule
and run the `cp`s towards to end.

This is a follow-up to #256 
