### PR TITLE
Bump nix version for testing to 2.7 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,8 +30,8 @@ nixpkgs_local_repository(
 )
 
 nixpkgs_package(
-    name = "nix_2_4",
-    attribute_path = "nix_2_4",
+    name = "nix_2_7",
+    attribute_path = "nixVersions.nix_2_7",
     repositories = {"nixpkgs": "@nixpkgs"},
 )
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -8,7 +8,7 @@ sh_test(
         "//nixpkgs:srcs",
         "//tests/invalid_nixpkgs_package:srcs",
         "@coreutils_static//:bin",
-        "@nix_2_4//:bin",
+        "@nix_2_7//:bin",
         "@rules_nixpkgs_cc//:srcs",
         "@rules_nixpkgs_core//:srcs",
         "@rules_nixpkgs_java//:srcs",

--- a/tests/test_invalid_nixpkgs_package.sh
+++ b/tests/test_invalid_nixpkgs_package.sh
@@ -17,7 +17,7 @@ sed "s;COREUTILS-ABS-PATH;${PWD}/external/coreutils_static/bin/;g" -i default.ni
 
 # Bring a specific version of Nix which can be executed in the Bazel
 # linux sandbox.
-export PATH=$PWD/external/nix_2_4/bin:$PATH
+export PATH=$PWD/external/nix_2_7/bin:$PATH
 
 # This is a create all directories required to run Nix locally.
 mkdir -p ${TEST_TMPDIR}/nix/{store,var/nix,etc/nix}


### PR DESCRIPTION
Nix version 2.4 is deprecated in nixpkgs unstable, and will be deprecated in the next stable nixpkgs release.
This also adds the nixVersions prefix to the attribute path, because specifiying a nix version without the nixVersions prefix also breaks on nixpkgs unstable.
This allows us to more easily test against nixpkgs unstable, which is necessary for testing against Bazel 6 prerelease at the moment. This is tested on both nixpkgs-22.05 and nixpkgs-unstable.