### PR TITLE
Skip writing to the remote cache with no API key - no. 2

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -60,9 +60,15 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
           cp .bazelrc.ci $HOME/.bazelrc
+          cp .bazelrc.ci $HOME/.bazelrc
+          if [ -z "$BUILDBUDDY_API_KEY" ]; then
+              cache_setting='build --noremote_upload_local_results'
+          else
+              cache_setting="build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
+          fi
           cat >>$HOME/.bazelrc <<EOF
           common --config=ci
-          build --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
+          $cache_setting
           # no-op flag to avoid "ERROR: Config value 'ci' is not defined in any .rc file"
           common:ci --announce_rc=false
           EOF


### PR DESCRIPTION
In PR #276 I failed to adapt the second "Configure" step of the "test-examples" job. Do this now.