### PR TITLE
toolchains/go: allow specifying go package by attribute_path

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -9,6 +9,7 @@ generate_documentation(
         "nixpkgs_package",
         "nixpkgs_cc_configure",
         "nixpkgs_cc_configure_deprecated",
+        "nixpkgs_go_configure",
         "nixpkgs_java_configure",
         "nixpkgs_python_configure",
         "nixpkgs_rust_configure",

--- a/toolchains/go/README.md
+++ b/toolchains/go/README.md
@@ -16,8 +16,8 @@ Rules for importing a Go toolchain from Nixpkgs.
 ### nixpkgs_go_configure
 
 <pre>
-nixpkgs_go_configure(<a href="#nixpkgs_go_configure-sdk_name">sdk_name</a>, <a href="#nixpkgs_go_configure-repository">repository</a>, <a href="#nixpkgs_go_configure-repositories">repositories</a>, <a href="#nixpkgs_go_configure-nix_file">nix_file</a>, <a href="#nixpkgs_go_configure-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_go_configure-nix_file_content">nix_file_content</a>,
-                     <a href="#nixpkgs_go_configure-nixopts">nixopts</a>, <a href="#nixpkgs_go_configure-fail_not_supported">fail_not_supported</a>, <a href="#nixpkgs_go_configure-quiet">quiet</a>)
+nixpkgs_go_configure(<a href="#nixpkgs_go_configure-sdk_name">sdk_name</a>, <a href="#nixpkgs_go_configure-repository">repository</a>, <a href="#nixpkgs_go_configure-repositories">repositories</a>, <a href="#nixpkgs_go_configure-attribute_path">attribute_path</a>, <a href="#nixpkgs_go_configure-nix_file">nix_file</a>, <a href="#nixpkgs_go_configure-nix_file_deps">nix_file_deps</a>,
+                     <a href="#nixpkgs_go_configure-nix_file_content">nix_file_content</a>, <a href="#nixpkgs_go_configure-nixopts">nixopts</a>, <a href="#nixpkgs_go_configure-fail_not_supported">fail_not_supported</a>, <a href="#nixpkgs_go_configure-quiet">quiet</a>)
 </pre>
 
 Use go toolchain from Nixpkgs.
@@ -147,6 +147,20 @@ Specify one of `path` or `repositories`.
 </p>
 </td>
 </tr>
+<tr id="nixpkgs_go_configure-attribute_path">
+<td><code>attribute_path</code></td>
+<td>
+
+optional.
+default is <code>"go"</code>
+
+<p>
+
+The nixpkgs attribute path for the `go` to use.
+
+</p>
+</td>
+</tr>
 <tr id="nixpkgs_go_configure-nix_file">
 <td><code>nix_file</code></td>
 <td>
@@ -156,7 +170,7 @@ default is <code>None</code>
 
 <p>
 
-An expression for a Nix environment derivation. The environment should expose the whole go SDK (`bin`, `src`, ...) at the root of package. It also must contain a `ROOT` file in the root of pacakge.
+An expression for a Nix environment derivation. The environment should expose the whole go SDK (`bin`, `src`, ...) at the root of package. It also must contain a `ROOT` file in the root of pacakge. Takes precedence over attribute_path.
 
 </p>
 </td>
@@ -184,7 +198,7 @@ default is <code>None</code>
 
 <p>
 
-An expression for a Nix environment derivation.
+An expression for a Nix environment derivation. Takes precedence over attribute_path.
 
 </p>
 </td>

--- a/toolchains/go/go.bzl
+++ b/toolchains/go/go.bzl
@@ -229,6 +229,7 @@ def nixpkgs_go_configure(
         sdk_name = "go_sdk",
         repository = None,
         repositories = {},
+        attribute_path = "go",
         nix_file = None,
         nix_file_deps = None,
         nix_file_content = None,
@@ -305,9 +306,10 @@ def nixpkgs_go_configure(
 
     Args:
       sdk_name: Go sdk name to pass to rules_go
-      nix_file: An expression for a Nix environment derivation. The environment should expose the whole go SDK (`bin`, `src`, ...) at the root of package. It also must contain a `ROOT` file in the root of pacakge.
+      attribute_path: The nixpkgs attribute path for the `go` to use.
+      nix_file: An expression for a Nix environment derivation. The environment should expose the whole go SDK (`bin`, `src`, ...) at the root of package. It also must contain a `ROOT` file in the root of pacakge. Takes precedence over attribute_path.
       nix_file_deps: Dependencies of `nix_file` if any.
-      nix_file_content: An expression for a Nix environment derivation.
+      nix_file_content: An expression for a Nix environment derivation. Takes precedence over attribute_path.
       repository: A repository label identifying which Nixpkgs to use. Equivalent to `repositories = { "nixpkgs": ...}`.
       repositories: A dictionary mapping `NIX_PATH` entries to repository labels.
 
@@ -324,17 +326,17 @@ def nixpkgs_go_configure(
 
     if not nix_file and not nix_file_content:
         nix_file_content = """
-            with import <nixpkgs> { config = {}; overlays = []; }; buildEnv {
+           with import <nixpkgs> {{ config = {{}}; overlays = []; }}; buildEnv {{
               name = "bazel-go-toolchain";
               paths = [
-                go
+                {attribute_path}
               ];
               postBuild = ''
                 touch $out/ROOT
-                ln -s $out/share/go/{api,doc,lib,misc,pkg,src} $out/
+                ln -s $out/share/go/{{api,doc,lib,misc,pkg,src}} $out/
               '';
-            }
-        """
+            }}
+        """.format(attribute_path = attribute_path)
 
     helpers_repo = sdk_name + "_helpers"
     nixpkgs_go_helpers(


### PR DESCRIPTION
Adds an `attribute_path` argument to `nixpkgs_go_configure`. 

Fixes #196.