### PR TITLE
cc: make CXX_FLAG configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ A dictionary from local repository name to global repository name. This allows c
 <pre>
 nixpkgs_cc_configure(<a href="#nixpkgs_cc_configure-name">name</a>, <a href="#nixpkgs_cc_configure-attribute_path">attribute_path</a>, <a href="#nixpkgs_cc_configure-nix_file">nix_file</a>, <a href="#nixpkgs_cc_configure-nix_file_content">nix_file_content</a>, <a href="#nixpkgs_cc_configure-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_cc_configure-repositories">repositories</a>,
                      <a href="#nixpkgs_cc_configure-repository">repository</a>, <a href="#nixpkgs_cc_configure-nixopts">nixopts</a>, <a href="#nixpkgs_cc_configure-quiet">quiet</a>, <a href="#nixpkgs_cc_configure-fail_not_supported">fail_not_supported</a>, <a href="#nixpkgs_cc_configure-exec_constraints">exec_constraints</a>,
-                     <a href="#nixpkgs_cc_configure-target_constraints">target_constraints</a>, <a href="#nixpkgs_cc_configure-register">register</a>)
+                     <a href="#nixpkgs_cc_configure-target_constraints">target_constraints</a>, <a href="#nixpkgs_cc_configure-register">register</a>, <a href="#nixpkgs_cc_configure-cc_lang">cc_lang</a>)
 </pre>
 
 Use a CC toolchain from Nixpkgs. No-op if not a nix-based platform.
@@ -531,6 +531,20 @@ default is <code>True</code>
 <p>
 
 bool, enabled by default, Whether to register (with `register_toolchains`) the generated toolchain and install it as the default cc_toolchain.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure-cc_lang">
+<td><code>cc_lang</code></td>
+<td>
+
+optional.
+default is <code>"c++"</code>
+
+<p>
+
+string, `"c++"` by default. Used to populate `CXX_FLAG` so the compiler is called in C++ mode. Can be set to `"none"` together with appropriate `copts` in the `cc_library` call: see above.
 
 </p>
 </td>

--- a/toolchains/cc/README.md
+++ b/toolchains/cc/README.md
@@ -4,6 +4,19 @@
 
 Rules for importing a C++ toolchain from Nixpkgs.
 
+## Compiling non-C++ languages
+
+One may wish to use a C++ toolchain to compile certain libraries written in
+non-C++ languages. For instance, Clang/LLVM can be used to compile CUDA or HIP
+code targeting GPUs. This can be achieved by:
+
+  1. passing `cc_lang = "none"` in `nixpkgs_cc_configure` below 
+  2. using a rule invocation of the form `cc_library(..., copts="-x cuda")`
+  when defining individual libraries or executables
+
+It is also possible to override the language used by the toolchain itself,
+using `nixpkgs_cc_configure(..., cc_lang = "cuda")` or similar.
+
 ## Rules
 
 * [nixpkgs_cc_configure](#nixpkgs_cc_configure)
@@ -18,7 +31,7 @@ Rules for importing a C++ toolchain from Nixpkgs.
 <pre>
 nixpkgs_cc_configure(<a href="#nixpkgs_cc_configure-name">name</a>, <a href="#nixpkgs_cc_configure-attribute_path">attribute_path</a>, <a href="#nixpkgs_cc_configure-nix_file">nix_file</a>, <a href="#nixpkgs_cc_configure-nix_file_content">nix_file_content</a>, <a href="#nixpkgs_cc_configure-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_cc_configure-repositories">repositories</a>,
                      <a href="#nixpkgs_cc_configure-repository">repository</a>, <a href="#nixpkgs_cc_configure-nixopts">nixopts</a>, <a href="#nixpkgs_cc_configure-quiet">quiet</a>, <a href="#nixpkgs_cc_configure-fail_not_supported">fail_not_supported</a>, <a href="#nixpkgs_cc_configure-exec_constraints">exec_constraints</a>,
-                     <a href="#nixpkgs_cc_configure-target_constraints">target_constraints</a>, <a href="#nixpkgs_cc_configure-register">register</a>)
+                     <a href="#nixpkgs_cc_configure-target_constraints">target_constraints</a>, <a href="#nixpkgs_cc_configure-register">register</a>, <a href="#nixpkgs_cc_configure-cc_lang">cc_lang</a>)
 </pre>
 
 Use a CC toolchain from Nixpkgs. No-op if not a nix-based platform.
@@ -252,6 +265,20 @@ default is <code>True</code>
 <p>
 
 bool, enabled by default, Whether to register (with `register_toolchains`) the generated toolchain and install it as the default cc_toolchain.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure-cc_lang">
+<td><code>cc_lang</code></td>
+<td>
+
+optional.
+default is <code>"c++"</code>
+
+<p>
+
+string, `"c++"` by default. Used to populate `CXX_FLAG` so the compiler is called in C++ mode. Can be set to `"none"` together with appropriate `copts` in the `cc_library` call: see above.
 
 </p>
 </td>

--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -6,6 +6,7 @@ in
 , ccAttrPath ? null
 , ccAttrSet ? null
 , ccExpr ? null
+, ccLang ? "c++"
 }:
 
 let
@@ -105,13 +106,13 @@ pkgs.runCommand "bazel-nixpkgs-cc-toolchain"
     is_compiler_option_supported() {
       local option="$1"
       local pattern="''${2-$1}"
-      { $cc "$option" -o /dev/null -c -x c++ - <<<"int main() {}" 2>&1 1>/dev/null || true; } \
+      { $cc "$option" -o /dev/null -c -x ${ccLang} - <<<"int main() {}" 2>&1 1>/dev/null || true; } \
         | grep -qe "$pattern" && return 1 || return 0
     }
     is_linker_option_supported() {
       local option="$1"
       local pattern="''${2-$1}"
-      { $cc "$option" -o /dev/null -x c++ - <<<"int main() {}" 2>&1 1>/dev/null || true; } \
+      { $cc "$option" -o /dev/null -x ${ccLang} - <<<"int main() {}" 2>&1 1>/dev/null || true; } \
         | grep -qe "$pattern" && return 1 || return 0
     }
     add_compiler_option_if_supported() {
@@ -176,7 +177,7 @@ pkgs.runCommand "bazel-nixpkgs-cc-toolchain"
       -fno-omit-frame-pointer
     )
     CXX_FLAGS=(
-      -x c++
+      -x ${ccLang}
       -std=c++0x
     )
     LINK_FLAGS=(


### PR DESCRIPTION
This offers an alternative to the solution proposed in #219 to the problem of `nixpkgs_cc_configure` providing a non-configurable `-x c++` in `CXX_OPTS` when calling a C compiler. We add a new optional `cc_lang` argument to `nixpkgs_cc_configure`, and then pass `-x <cc_lang>` instead.

Fixes #218.