### PR TITLE
Fix Python container example

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -110,8 +110,10 @@ jobs:
 
           popd
 
-          pushd examples/python-container
-          echo
-          echo "::group::Running $(head -n1 README.md) with Nix"
-          nix-shell --command 'bazel build :hello_image'
-          popd
+          if [[ ${{ matrix.os }} = ubuntu* ]]; then
+            pushd examples/python-container
+            echo
+            echo "::group::Running $(head -n1 README.md) with Nix"
+            nix-shell --command 'bazel build :hello_image'
+            popd
+          fi

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -88,22 +88,30 @@ jobs:
             read -a ${1} <<< $(echo ${!p//$2})
           }
 
-          cd examples/toolchains
+          pushd examples/toolchains
           with_nix=( $(ls) )
           without_nix=( cc go java rust )
 
           for dir in "${with_nix[@]}"; do
-              cd "$dir"
+              pushd "$dir"
               echo
               echo "::group::Running $(head -n1 README.md) with Nix"
               nix-shell --command 'bazel run --config=nix :hello'
               # TODO: all toolchains should run without Nixpkgs
-              cd ..
+              popd
           done
           for dir in "${without_nix[@]}"; do
-              cd "$dir"
+              pushd "$dir"
               echo
               echo "::group::Running $(head -n1 README.md) without Nix"
               bazel run :hello
-              cd ..
+              popd
           done
+
+          popd
+
+          pushd examples/python-container
+          echo
+          echo "::group::Running $(head -n1 README.md) with Nix"
+          nix-shell --command 'bazel build --config=nix :hello_image'
+          popd

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -113,5 +113,5 @@ jobs:
           pushd examples/python-container
           echo
           echo "::group::Running $(head -n1 README.md) with Nix"
-          nix-shell --command 'bazel build --config=nix :hello_image'
+          nix-shell --command 'bazel build :hello_image'
           popd

--- a/examples/python-container/.bazelrc
+++ b/examples/python-container/.bazelrc
@@ -1,1 +1,2 @@
 build:nix --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
+build:nix --crosstool_top=@nixpkgs_config_cc//:toolchain

--- a/examples/python-container/.bazelrc
+++ b/examples/python-container/.bazelrc
@@ -1,2 +1,0 @@
-build:nix --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
-build:nix --crosstool_top=@nixpkgs_config_cc//:toolchain

--- a/examples/python-container/BUILD
+++ b/examples/python-container/BUILD
@@ -8,6 +8,14 @@ load("@io_bazel_rules_docker//python3:image.bzl", "py3_image")
 
 package(default_visibility = ["//visibility:public"])
 
+platform(
+    name = "nix_container_platform",
+    constraint_values = [
+        "@io_bazel_rules_docker//platforms:run_in_container",
+    ],
+    parents = ["@io_tweag_rules_nixpkgs//nixpkgs/platforms:host"],
+)
+
 py3_image(
     name = "hello_image",
     srcs = [ "hello.py" ],

--- a/examples/python-container/README.md
+++ b/examples/python-container/README.md
@@ -47,11 +47,11 @@ Expect something like this as output:
 
 ## Step 2: Nix-Environment with bazel
 
-We're using Nix 21.11 (stable at the time of writing) and Bazel version 4, so
+We're using Nix 22.05 (stable at the time of writing) and Bazel version 5, so
 create a file `shell.nix` wit the following content:
 
 ```
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/refs/tags/21.11.tar.gz") {} }:
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/refs/tags/22.05.tar.gz") {} }:
 
 pkgs.mkShellNoCC {
     nativeBuildInputs = [
@@ -69,7 +69,7 @@ nix-shell --pure --command 'bazel --version'
 You get something like
 
 ```
-bazel 4.2.1- (@non-git)
+bazel 5.1.1- (@non-git)
 ```
 
 ---

--- a/examples/python-container/WORKSPACE
+++ b/examples/python-container/WORKSPACE
@@ -22,6 +22,13 @@ nixpkgs_git_repository(
     sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
 )
 
+# Configure the C++ toolchain
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_cc_configure")
+nixpkgs_cc_configure(
+    name = "nixpkgs_config_cc",
+    repository = "@nixpkgs",
+)
+
 # Configure python
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_python_configure")
 nixpkgs_python_configure(

--- a/examples/python-container/WORKSPACE
+++ b/examples/python-container/WORKSPACE
@@ -4,11 +4,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 ######################
 # Tweag Nix Support
 ######################
-http_archive(
+
+# Replace with http_archive: https://github.com/tweag/rules_nixpkgs/#setup
+local_repository(
     name = "io_tweag_rules_nixpkgs",
-    sha256 = "7aee35c95251c1751e765f7da09c3bb096d41e6d6dca3c72544781a5573be4aa",
-    strip_prefix = "rules_nixpkgs-0.8.0",
-    urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.8.0.tar.gz"],
+    path = "../../",
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")

--- a/examples/python-container/WORKSPACE
+++ b/examples/python-container/WORKSPACE
@@ -14,7 +14,7 @@ http_archive(
 load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
 rules_nixpkgs_dependencies()
 
-# Define nixpkgs version 21.11
+# Define nixpkgs version
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository")
 nixpkgs_git_repository(
     name = "nixpkgs",

--- a/examples/python-container/WORKSPACE
+++ b/examples/python-container/WORKSPACE
@@ -25,8 +25,16 @@ nixpkgs_git_repository(
 # Configure the C++ toolchain
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_cc_configure")
 nixpkgs_cc_configure(
-    name = "nixpkgs_config_cc",
     repository = "@nixpkgs",
+    exec_constraints = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+        "@io_bazel_rules_docker//platforms:run_in_container",
+    ],
+    target_constraints = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
 )
 
 # Configure python
@@ -71,3 +79,8 @@ exports_files(["image"])
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_load" )
 container_load(name = "python39_base_image", file = "@raw_python39_base_image//:image")
+
+register_execution_platforms(
+    "@io_tweag_rules_nixpkgs//nixpkgs/platforms:host",
+    "@//:nix_container_platform",
+)

--- a/examples/python-container/nixpkgs.json
+++ b/examples/python-container/nixpkgs.json
@@ -1,0 +1,7 @@
+{
+  "owner": "NixOS",
+  "repo": "nixpkgs",
+  "branch": "22.05",
+  "rev": "ce6aa13369b667ac2542593170993504932eb836",
+  "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik"
+}

--- a/examples/python-container/nixpkgs.nix
+++ b/examples/python-container/nixpkgs.nix
@@ -1,0 +1,8 @@
+let
+  spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+  nixpkgs = fetchTarball {
+    url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
+    sha256 = spec.sha256;
+  };
+in
+import nixpkgs

--- a/examples/python-container/shell.nix
+++ b/examples/python-container/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/refs/tags/21.11.tar.gz") {} }:
+{ pkgs ? import ./nixpkgs.nix { } }:
 
 pkgs.mkShellNoCC {
     nativeBuildInputs = [


### PR DESCRIPTION
The example was still using an older nixpkgs revision that did not provide the required Bazel version 5. This PR updates the nixpkgs revision. This PR also adds the example to at least build the image on CI, to make sure that we notice any such discrepancies in the future.