### PR TITLE
Remove any docs references from core

### DIFF
--- a/core/.bazelrc
+++ b/core/.bazelrc
@@ -1,6 +1,5 @@
 build --host_platform=@rules_nixpkgs_core//platforms:host
 
-build --crosstool_top=@nixpkgs_config_cc//:toolchain
 # Using toolchain resolution can lead to spurious dependencies on
 # `@local_config_cc//:builtin_include_directory_paths`. This needs to be
 # resolved before `--incompatible_enable_cc_toolchain_resolution` can be

--- a/core/WORKSPACE
+++ b/core/WORKSPACE
@@ -8,7 +8,7 @@ local_repository(
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
 
-rules_nixpkgs_dependencies(toolchains = ['cc', 'java', 'posix'])
+rules_nixpkgs_dependencies(toolchains = ['java', 'posix'])
 
 ### dependencies for tests
 

--- a/core/WORKSPACE
+++ b/core/WORKSPACE
@@ -1,31 +1,14 @@
 # NOTE: temporary boilerplate for compatibility with `WORKSPACE` setup!
 # TODO: remove when migration to `bzlmod` is complete
 
-### generic dependencies for rendering documentation
-
 local_repository(
     name = "io_tweag_rules_nixpkgs",
     path = "..",
 )
 
-local_repository(
-    name = "rules_nixpkgs_docs",
-    path = "../docs",
-)
-
 load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
 
 rules_nixpkgs_dependencies(toolchains = ['cc', 'java', 'posix'])
-
-load("@rules_nixpkgs_docs//:dependencies_1.bzl", "docs_dependencies_1")
-
-docs_dependencies_1()
-
-load("@rules_nixpkgs_docs//:dependencies_2.bzl", "docs_dependencies_2")
-
-docs_dependencies_2()
-
-### end generic dependencies for rendering documentation
 
 ### dependencies for tests
 
@@ -36,6 +19,12 @@ load(
     "nixpkgs_package",
 )
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+load("//:test_dependencies_1.bzl", "test_dependencies_1")
+test_dependencies_1()
+
+load("//:test_dependencies_2.bzl", "test_dependencies_2")
+test_dependencies_2()
 
 bazel_skylib_workspace()
 

--- a/core/test_dependencies_1.bzl
+++ b/core/test_dependencies_1.bzl
@@ -1,0 +1,20 @@
+# NOTE: temporary for compatibility with `WORKSPACE` setup!
+# TODO: remove when migration to `bzlmod` is complete
+
+# This has to be split into `test_dependencies_1` and `test_dependencies_2`
+# because Bazel is imperative, and requires `load()` to be a top-level
+# statement.
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def test_dependencies_1():
+    """
+    Load repositories required for runnings tests for `rules_nixpkgs_*`
+    """
+    maybe(
+        http_archive,
+        "rules_sh",
+        sha256 = "d668bb32f112ead69c58bde2cae62f6b8acefe759a8c95a2d80ff6a85af5ac5e",
+        strip_prefix = "rules_sh-0.3.0",
+        urls = ["https://github.com/tweag/rules_sh/archive/v0.3.0.tar.gz"],
+    )

--- a/core/test_dependencies_2.bzl
+++ b/core/test_dependencies_2.bzl
@@ -1,0 +1,41 @@
+# NOTE: temporary for compatibility with `WORKSPACE` setup!
+# TODO: remove when migration to `bzlmod` is complete
+
+# This has to be split into `test_dependencies_1` and `test_dependencies_2`
+# because Bazel is imperative, and requires `load()` to be a top-level
+# statement.
+load("@rules_nixpkgs_core//:nixpkgs.bzl", "nixpkgs_local_repository")
+load("@rules_nixpkgs_java//:java.bzl", "nixpkgs_java_configure")
+load("@rules_sh//sh:repositories.bzl", "rules_sh_dependencies")
+load("@rules_sh//sh:posix.bzl", "sh_posix_configure")
+load("@rules_nixpkgs_posix//:posix.bzl", "nixpkgs_sh_posix_configure")
+load("@rules_nixpkgs_cc//:cc.bzl", "nixpkgs_cc_configure")
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+def test_dependencies_2():
+    nixpkgs_local_repository(
+        name = "nixpkgs",
+        nix_file = "@rules_nixpkgs_core//:nixpkgs.nix",
+        nix_file_deps = ["@rules_nixpkgs_core//:flake.lock"],
+    )
+
+    rules_sh_dependencies()
+    nixpkgs_sh_posix_configure(repository = "@nixpkgs")
+    sh_posix_configure()
+
+    nixpkgs_cc_configure(
+        name = "nixpkgs_config_cc",
+        repository = "@nixpkgs",
+    )
+
+    rules_java_dependencies()
+
+    nixpkgs_java_configure(
+        attribute_path = "jdk11.home",
+        repository = "@nixpkgs",
+        toolchain = True,
+        toolchain_name = "nixpkgs_java",
+        toolchain_version = "11",
+    )
+
+    rules_java_toolchains()

--- a/core/test_dependencies_2.bzl
+++ b/core/test_dependencies_2.bzl
@@ -9,7 +9,6 @@ load("@rules_nixpkgs_java//:java.bzl", "nixpkgs_java_configure")
 load("@rules_sh//sh:repositories.bzl", "rules_sh_dependencies")
 load("@rules_sh//sh:posix.bzl", "sh_posix_configure")
 load("@rules_nixpkgs_posix//:posix.bzl", "nixpkgs_sh_posix_configure")
-load("@rules_nixpkgs_cc//:cc.bzl", "nixpkgs_cc_configure")
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
 
 def test_dependencies_2():
@@ -22,11 +21,6 @@ def test_dependencies_2():
     rules_sh_dependencies()
     nixpkgs_sh_posix_configure(repository = "@nixpkgs")
     sh_posix_configure()
-
-    nixpkgs_cc_configure(
-        name = "nixpkgs_config_cc",
-        repository = "@nixpkgs",
-    )
 
     rules_java_dependencies()
 

--- a/toolchains/cc/.bazelrc
+++ b/toolchains/cc/.bazelrc
@@ -1,1 +1,23 @@
-../../core/.bazelrc
+build --host_platform=@rules_nixpkgs_core//platforms:host
+
+build --crosstool_top=@nixpkgs_config_cc//:toolchain
+# Using toolchain resolution can lead to spurious dependencies on
+# `@local_config_cc//:builtin_include_directory_paths`. This needs to be
+# resolved before `--incompatible_enable_cc_toolchain_resolution` can be
+# recommended for `nixpkgs_cc_configure_hermetic`.
+# build --incompatible_enable_cc_toolchain_resolution
+
+build --java_runtime_version=nixpkgs_java_11
+build --java_language_version=11
+build --tool_java_runtime_version=nixpkgs_java_11
+build --tool_java_language_version=11
+
+# The following lines provide a workaround for a test failure in on the Java
+# toolchain on MacOS 11, documented here: https://github.com/tweag/rules_nixpkgs/issues/299.
+# They should be removed as soon as that issue has been resolved.
+build --enable_platform_specific_config
+build:macos --experimental_strict_java_deps=warn
+
+# User Configuration
+# ------------------
+try-import %workspace%/.bazelrc.local

--- a/toolchains/cc/WORKSPACE
+++ b/toolchains/cc/WORKSPACE
@@ -26,3 +26,10 @@ load("@rules_nixpkgs_docs//:dependencies_2.bzl", "docs_dependencies_2")
 docs_dependencies_2()
 
 ### end generic dependencies for rendering documentation
+
+load("@rules_nixpkgs_cc//:cc.bzl", "nixpkgs_cc_configure")
+
+nixpkgs_cc_configure(
+    name = "nixpkgs_config_cc",
+    repository = "@nixpkgs",
+)

--- a/toolchains/go/.bazelrc
+++ b/toolchains/go/.bazelrc
@@ -1,1 +1,23 @@
-../../core/.bazelrc
+build --host_platform=@rules_nixpkgs_core//platforms:host
+
+build --crosstool_top=@nixpkgs_config_cc//:toolchain
+# Using toolchain resolution can lead to spurious dependencies on
+# `@local_config_cc//:builtin_include_directory_paths`. This needs to be
+# resolved before `--incompatible_enable_cc_toolchain_resolution` can be
+# recommended for `nixpkgs_cc_configure_hermetic`.
+# build --incompatible_enable_cc_toolchain_resolution
+
+build --java_runtime_version=nixpkgs_java_11
+build --java_language_version=11
+build --tool_java_runtime_version=nixpkgs_java_11
+build --tool_java_language_version=11
+
+# The following lines provide a workaround for a test failure in on the Java
+# toolchain on MacOS 11, documented here: https://github.com/tweag/rules_nixpkgs/issues/299.
+# They should be removed as soon as that issue has been resolved.
+build --enable_platform_specific_config
+build:macos --experimental_strict_java_deps=warn
+
+# User Configuration
+# ------------------
+try-import %workspace%/.bazelrc.local


### PR DESCRIPTION
The `docs` module was not used directly, although its dependencies were used by core (except `stardoc`).

Related to #264 and #296