### PR TITLE
Add example for nodejs toolchain with npm_install repository rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /**/bazel-*
+
+/**/node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/tweag/rules_nixpkgs/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/tweag/rules_nixpkgs/compare/v0.9.0...HEAD
+
+### Added
+- nixpkgs_nodejs_configure_platforms for platform transparent npm_install
+  See [#309]
 
 ## [0.9.0] - 2022-07-19
 
-[0.9.0]: https://github.com/tweag/rules_nixpkgs/compare/v0.9.0...v0.9.0
+[0.9.0]: https://github.com/tweag/rules_nixpkgs/compare/v0.8.0...v0.9.0
 
 ### Added
 

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -21,6 +21,7 @@ generate_documentation(
         "nixpkgs_rust_configure",
         "nixpkgs_sh_posix_configure",
         "nixpkgs_nodejs_configure",
+        "nixpkgs_nodejs_configure_platforms",
     ],
     deps = [
         "@io_tweag_rules_nixpkgs//nixpkgs",

--- a/examples/toolchains/nodejs/BUILD
+++ b/examples/toolchains/nodejs/BUILD
@@ -2,4 +2,5 @@ load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 nodejs_binary(
     name = "hello",
     entry_point = ":hello.js",
+    data = [ "@npm//ololog", ]
 )

--- a/examples/toolchains/nodejs/WORKSPACE
+++ b/examples/toolchains/nodejs/WORKSPACE
@@ -28,9 +28,9 @@ nixpkgs_git_repository(
     sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
 )
 
-load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_nodejs_configure")
-nixpkgs_nodejs_configure(
-  name = "nixpkgs-nodejs_linux_amd64",
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_nodejs_configure_platforms")
+nixpkgs_nodejs_configure_platforms(
+  name = "nixpkgs-nodejs",
   repository = "@nixpkgs",
 )
 

--- a/examples/toolchains/nodejs/WORKSPACE
+++ b/examples/toolchains/nodejs/WORKSPACE
@@ -7,15 +7,9 @@ local_repository(
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "rules_nodejs",
-    sha256 = "5aef09ed3279aa01d5c928e3beb248f9ad32dde6aafe6373a8c994c3ce643064",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.3/rules_nodejs-core-5.5.3.tar.gz"],
-)
-
-http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "f10a3a12894fc3c9bf578ee5a5691769f6805c4be84359681a785a0c12e8d2b6",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.3/rules_nodejs-5.5.3.tar.gz"],
+    sha256 = "dcc55f810142b6cf46a44d0180a5a7fb923c04a5061e2e8d8eb05ccccc60864b",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.0/rules_nodejs-5.8.0.tar.gz"],
 )
 
 load("@build_bazel_rules_nodejs//:repositories.bzl", "build_bazel_rules_nodejs_dependencies")
@@ -35,11 +29,17 @@ nixpkgs_git_repository(
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_nodejs_configure")
-
 nixpkgs_nodejs_configure(
+  name = "nixpkgs-nodejs_linux_amd64",
   repository = "@nixpkgs",
 )
 
-load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
+load("@build_bazel_rules_nodejs//:index.bzl", "npm_install")
+npm_install(
+    name = "npm",
+    exports_directories_only = True,
+    node_repository = "nixpkgs-nodejs",
+    package_json = "//:package.json",
+    package_lock_json = "//:package-lock.json",
+)
 
-node_repositories()

--- a/examples/toolchains/nodejs/hello.js
+++ b/examples/toolchains/nodejs/hello.js
@@ -1,1 +1,4 @@
-console.log("Hello world!")
+const log = require ('ololog')
+
+log("Hello world!")
+

--- a/examples/toolchains/nodejs/package-lock.json
+++ b/examples/toolchains/nodejs/package-lock.json
@@ -1,0 +1,179 @@
+{
+  "name": "nodejs",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "ololog": "^1.1.175"
+      }
+    },
+    "node_modules/ansicolor": {
+      "version": "1.1.100",
+      "resolved": "https://registry.npmjs.org/ansicolor/-/ansicolor-1.1.100.tgz",
+      "integrity": "sha512-Jl0pxRfa9WaQVUX57AB8/V2my6FJxrOR1Pp2qqFbig20QB4HzUoQ48THTKAgHlUCJeQm/s2WoOPcoIDhyCL/kw=="
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA=="
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/ololog": {
+      "version": "1.1.175",
+      "resolved": "https://registry.npmjs.org/ololog/-/ololog-1.1.175.tgz",
+      "integrity": "sha512-DSPbsvZzLshFiPI1ul7iJDn6wI75goOLyrn8uRB92sPon5LS8J2KlAIkSoHXtRztb2idPjuzq3R1J58hN2qOEA==",
+      "dependencies": {
+        "ansicolor": "^1.1.84",
+        "pipez": "^1.1.12",
+        "printable-characters": "^1.0.42",
+        "stacktracey": "^2.1.6",
+        "string.bullet": "^1.0.12",
+        "string.ify": "^1.0.64"
+      }
+    },
+    "node_modules/pipez": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/pipez/-/pipez-1.1.12.tgz",
+      "integrity": "sha512-VuJ+c44f3s/4cirqtBI3wa0LscCo1IG9sQH2DnClJWEMkGylE52mDjLLHR5QyLjij1EiGocMEIAJsmpyXczXJQ=="
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ=="
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktracey": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.1.8.tgz",
+      "integrity": "sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/string.bullet": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/string.bullet/-/string.bullet-1.0.12.tgz",
+      "integrity": "sha512-6+tQyad/ux52N+7wUcjmxeK5TfdeykBBLHQPk8MxUVrk9JwHzJnuxsJzjjpWAuz0x3EmnVGCg0ibMHqez1l/qQ==",
+      "dependencies": {
+        "printable-characters": "^1.0.26"
+      }
+    },
+    "node_modules/string.ify": {
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/string.ify/-/string.ify-1.0.64.tgz",
+      "integrity": "sha512-4Aa5yndnuOhE1GV2W3ht4rQ08XHq46JLXmSOv0jeUWEzqliBvm8lAXvt+66np+J9DkoCZikFzTzjXVLRR0F/Xw==",
+      "dependencies": {
+        "printable-characters": "^1.0.42",
+        "string.bullet": "^1.0.12"
+      }
+    }
+  },
+  "dependencies": {
+    "ansicolor": {
+      "version": "1.1.100",
+      "resolved": "https://registry.npmjs.org/ansicolor/-/ansicolor-1.1.100.tgz",
+      "integrity": "sha512-Jl0pxRfa9WaQVUX57AB8/V2my6FJxrOR1Pp2qqFbig20QB4HzUoQ48THTKAgHlUCJeQm/s2WoOPcoIDhyCL/kw=="
+    },
+    "as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "requires": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA=="
+    },
+    "get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "requires": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "ololog": {
+      "version": "1.1.175",
+      "resolved": "https://registry.npmjs.org/ololog/-/ololog-1.1.175.tgz",
+      "integrity": "sha512-DSPbsvZzLshFiPI1ul7iJDn6wI75goOLyrn8uRB92sPon5LS8J2KlAIkSoHXtRztb2idPjuzq3R1J58hN2qOEA==",
+      "requires": {
+        "ansicolor": "^1.1.84",
+        "pipez": "^1.1.12",
+        "printable-characters": "^1.0.42",
+        "stacktracey": "^2.1.6",
+        "string.bullet": "^1.0.12",
+        "string.ify": "^1.0.64"
+      }
+    },
+    "pipez": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/pipez/-/pipez-1.1.12.tgz",
+      "integrity": "sha512-VuJ+c44f3s/4cirqtBI3wa0LscCo1IG9sQH2DnClJWEMkGylE52mDjLLHR5QyLjij1EiGocMEIAJsmpyXczXJQ=="
+    },
+    "printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ=="
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "stacktracey": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.1.8.tgz",
+      "integrity": "sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==",
+      "requires": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "string.bullet": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/string.bullet/-/string.bullet-1.0.12.tgz",
+      "integrity": "sha512-6+tQyad/ux52N+7wUcjmxeK5TfdeykBBLHQPk8MxUVrk9JwHzJnuxsJzjjpWAuz0x3EmnVGCg0ibMHqez1l/qQ==",
+      "requires": {
+        "printable-characters": "^1.0.26"
+      }
+    },
+    "string.ify": {
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/string.ify/-/string.ify-1.0.64.tgz",
+      "integrity": "sha512-4Aa5yndnuOhE1GV2W3ht4rQ08XHq46JLXmSOv0jeUWEzqliBvm8lAXvt+66np+J9DkoCZikFzTzjXVLRR0F/Xw==",
+      "requires": {
+        "printable-characters": "^1.0.42",
+        "string.bullet": "^1.0.12"
+      }
+    }
+  }
+}

--- a/examples/toolchains/nodejs/package.json
+++ b/examples/toolchains/nodejs/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "ololog": "^1.1.175"
+  }
+}

--- a/examples/toolchains/nodejs/shell.nix
+++ b/examples/toolchains/nodejs/shell.nix
@@ -1,3 +1,3 @@
 { pkgs ? import ./nixpkgs.nix { } }:
 
-pkgs.mkShellNoCC { nativeBuildInputs = [ pkgs.bazel_6 ]; }
+pkgs.mkShellNoCC { nativeBuildInputs = with pkgs; [ bazel_6 nodejs ]; }

--- a/examples/toolchains/nodejs/shell.nix
+++ b/examples/toolchains/nodejs/shell.nix
@@ -1,3 +1,3 @@
 { pkgs ? import ./nixpkgs.nix { } }:
 
-pkgs.mkShellNoCC { nativeBuildInputs = with pkgs; [ bazel_6 nodejs ]; }
+pkgs.mkShellNoCC { nativeBuildInputs = with pkgs; [ bazel_6 ]; }

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -150,6 +150,7 @@ load(
 load(
     "@rules_nixpkgs_nodejs//:nodejs.bzl",
     _nixpkgs_nodejs_configure = "nixpkgs_nodejs_configure",
+    _nixpkgs_nodejs_configure_platforms = "nixpkgs_nodejs_configure_platforms",
 )
 
 # aliases for backwards compatibility prior to `bzlmod`
@@ -162,6 +163,7 @@ nixpkgs_cc_configure = _nixpkgs_cc_configure
 nixpkgs_rust_configure = _nixpkgs_rust_configure
 nixpkgs_sh_posix_configure = _nixpkgs_sh_posix_configure
 nixpkgs_nodejs_configure = _nixpkgs_nodejs_configure
+nixpkgs_nodejs_configure_platforms = _nixpkgs_nodejs_configure_platforms
 
 def nixpkgs_cc_autoconf_impl(repository_ctx):
     cpu_value = get_cpu_value(repository_ctx)

--- a/nixpkgs/repositories.bzl
+++ b/nixpkgs/repositories.bzl
@@ -36,6 +36,12 @@ def rules_nixpkgs_dependencies(rules_nixpkgs_name = "io_tweag_rules_nixpkgs", to
         strip_prefix = "rules_java-5.0.0",
         url = "https://github.com/bazelbuild/rules_java/archive/refs/tags/5.0.0.tar.gz",
     )
+    maybe(
+        http_archive,
+        "rules_nodejs",
+        sha256 = "08337d4fffc78f7fe648a93be12ea2fc4e8eb9795a4e6aa48595b66b34555626",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.0/rules_nodejs-core-5.8.0.tar.gz"],
+    )
 
     # the following complication is due to migrating to `bzlmod`.
     # fetch extracted submodules as external repositories from an existing source tree, based on the import type.

--- a/toolchains/nodejs/BUILD.bazel
+++ b/toolchains/nodejs/BUILD.bazel
@@ -13,5 +13,6 @@ bzl_library(
     srcs = ["//:nodejs.bzl"],
     deps = [
         "@rules_nixpkgs_core//:nixpkgs",
+        "@rules_nodejs//nodejs:bzl",
     ],
 )

--- a/toolchains/nodejs/README.md
+++ b/toolchains/nodejs/README.md
@@ -9,9 +9,9 @@
 ### nixpkgs_nodejs_configure
 
 <pre>
-nixpkgs_nodejs_configure(<a href="#nixpkgs_nodejs_configure-name">name</a>, <a href="#nixpkgs_nodejs_configure-attribute_path">attribute_path</a>, <a href="#nixpkgs_nodejs_configure-repository">repository</a>, <a href="#nixpkgs_nodejs_configure-repositories">repositories</a>, <a href="#nixpkgs_nodejs_configure-nix_file">nix_file</a>, <a href="#nixpkgs_nodejs_configure-nix_file_content">nix_file_content</a>,
-                         <a href="#nixpkgs_nodejs_configure-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_nodejs_configure-nixopts">nixopts</a>, <a href="#nixpkgs_nodejs_configure-fail_not_supported">fail_not_supported</a>, <a href="#nixpkgs_nodejs_configure-quiet">quiet</a>, <a href="#nixpkgs_nodejs_configure-exec_constraints">exec_constraints</a>,
-                         <a href="#nixpkgs_nodejs_configure-target_constraints">target_constraints</a>)
+nixpkgs_nodejs_configure(<a href="#nixpkgs_nodejs_configure-name">name</a>, <a href="#nixpkgs_nodejs_configure-attribute_path">attribute_path</a>, <a href="#nixpkgs_nodejs_configure-repository">repository</a>, <a href="#nixpkgs_nodejs_configure-repositories">repositories</a>, <a href="#nixpkgs_nodejs_configure-nix_platform">nix_platform</a>, <a href="#nixpkgs_nodejs_configure-nix_file">nix_file</a>,
+                         <a href="#nixpkgs_nodejs_configure-nix_file_content">nix_file_content</a>, <a href="#nixpkgs_nodejs_configure-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_nodejs_configure-nixopts">nixopts</a>, <a href="#nixpkgs_nodejs_configure-fail_not_supported">fail_not_supported</a>, <a href="#nixpkgs_nodejs_configure-quiet">quiet</a>,
+                         <a href="#nixpkgs_nodejs_configure-exec_constraints">exec_constraints</a>, <a href="#nixpkgs_nodejs_configure-target_constraints">target_constraints</a>)
 </pre>
 
 
@@ -57,6 +57,15 @@ default is <code>None</code>
 
 optional.
 default is <code>{}</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_nodejs_configure-nix_platform">
+<td><code>nix_platform</code></td>
+<td>
+
+optional.
+default is <code>None</code>
 
 </td>
 </tr>

--- a/toolchains/nodejs/README.md
+++ b/toolchains/nodejs/README.md
@@ -145,3 +145,173 @@ default is <code>None</code>
 </table>
 
 
+<a id="#nixpkgs_nodejs_configure_platforms"></a>
+
+### nixpkgs_nodejs_configure_platforms
+
+<pre>
+nixpkgs_nodejs_configure_platforms(<a href="#nixpkgs_nodejs_configure_platforms-name">name</a>, <a href="#nixpkgs_nodejs_configure_platforms-platforms_mapping">platforms_mapping</a>, <a href="#nixpkgs_nodejs_configure_platforms-attribute_path">attribute_path</a>, <a href="#nixpkgs_nodejs_configure_platforms-repository">repository</a>,
+                                   <a href="#nixpkgs_nodejs_configure_platforms-repositories">repositories</a>, <a href="#nixpkgs_nodejs_configure_platforms-nix_platform">nix_platform</a>, <a href="#nixpkgs_nodejs_configure_platforms-nix_file">nix_file</a>, <a href="#nixpkgs_nodejs_configure_platforms-nix_file_content">nix_file_content</a>,
+                                   <a href="#nixpkgs_nodejs_configure_platforms-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_nodejs_configure_platforms-nixopts">nixopts</a>, <a href="#nixpkgs_nodejs_configure_platforms-fail_not_supported">fail_not_supported</a>, <a href="#nixpkgs_nodejs_configure_platforms-quiet">quiet</a>,
+                                   <a href="#nixpkgs_nodejs_configure_platforms-exec_constraints">exec_constraints</a>, <a href="#nixpkgs_nodejs_configure_platforms-target_constraints">target_constraints</a>, <a href="#nixpkgs_nodejs_configure_platforms-kwargs">kwargs</a>)
+</pre>
+
+Runs nixpkgs_nodejs_configure for each platform.
+
+Since rules_nodejs adds platform suffix to repository name, this can be helpful
+if one wants to use npm_install and reference js dependencies from npm repo.
+See the example directory.
+
+
+#### Parameters
+
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+<tr id="nixpkgs_nodejs_configure_platforms-name">
+<td><code>name</code></td>
+<td>
+
+optional.
+default is <code>"nixpkgs_nodejs"</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_nodejs_configure_platforms-platforms_mapping">
+<td><code>platforms_mapping</code></td>
+<td>
+
+optional.
+default is <code>{"aarch64-darwin": struct(exec_constraints = ["@platforms//os:macos", "@platforms//cpu:arm64"], rules_nodejs_platform = "darwin_arm64", target_constraints = ["@platforms//os:macos", "@platforms//cpu:arm64"]), "x86_64-linux": struct(exec_constraints = ["@platforms//os:linux", "@platforms//cpu:x86_64"], rules_nodejs_platform = "linux_amd64", target_constraints = ["@platforms//os:linux", "@platforms//cpu:x86_64"]), "x86_64-darwin": struct(exec_constraints = ["@platforms//os:macos", "@platforms//cpu:x86_64"], rules_nodejs_platform = "darwin_amd64", target_constraints = ["@platforms//os:macos", "@platforms//cpu:x86_64"]), "aarch64-linux": struct(exec_constraints = ["@platforms//os:linux", "@platforms//cpu:arm64"], rules_nodejs_platform = "linux_arm64", target_constraints = ["@platforms//os:linux", "@platforms//cpu:arm64"])}</code>
+
+<p>
+
+struct describing mapping between nix platform and rules_nodejs bazel platform with
+target and exec constraints
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_nodejs_configure_platforms-attribute_path">
+<td><code>attribute_path</code></td>
+<td>
+
+optional.
+default is <code>"nodejs"</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_nodejs_configure_platforms-repository">
+<td><code>repository</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_nodejs_configure_platforms-repositories">
+<td><code>repositories</code></td>
+<td>
+
+optional.
+default is <code>{}</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_nodejs_configure_platforms-nix_platform">
+<td><code>nix_platform</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_nodejs_configure_platforms-nix_file">
+<td><code>nix_file</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_nodejs_configure_platforms-nix_file_content">
+<td><code>nix_file_content</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_nodejs_configure_platforms-nix_file_deps">
+<td><code>nix_file_deps</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_nodejs_configure_platforms-nixopts">
+<td><code>nixopts</code></td>
+<td>
+
+optional.
+default is <code>[]</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_nodejs_configure_platforms-fail_not_supported">
+<td><code>fail_not_supported</code></td>
+<td>
+
+optional.
+default is <code>True</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_nodejs_configure_platforms-quiet">
+<td><code>quiet</code></td>
+<td>
+
+optional.
+default is <code>False</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_nodejs_configure_platforms-exec_constraints">
+<td><code>exec_constraints</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_nodejs_configure_platforms-target_constraints">
+<td><code>target_constraints</code></td>
+<td>
+
+optional.
+default is <code>None</code>
+
+</td>
+</tr>
+<tr id="nixpkgs_nodejs_configure_platforms-kwargs">
+<td><code>kwargs</code></td>
+<td>
+
+optional.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+

--- a/toolchains/nodejs/WORKSPACE
+++ b/toolchains/nodejs/WORKSPACE
@@ -31,8 +31,14 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "f10a3a12894fc3c9bf578ee5a5691769f6805c4be84359681a785a0c12e8d2b6",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.3/rules_nodejs-5.5.3.tar.gz"],
+    sha256 = "dcc55f810142b6cf46a44d0180a5a7fb923c04a5061e2e8d8eb05ccccc60864b",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.0/rules_nodejs-5.8.0.tar.gz"],
+)
+
+http_archive(
+    name = "rules_nodejs",
+    sha256 = "08337d4fffc78f7fe648a93be12ea2fc4e8eb9795a4e6aa48595b66b34555626",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.0/rules_nodejs-core-5.8.0.tar.gz"],
 )
 
 load("//:nodejs.bzl", "nixpkgs_nodejs_configure")

--- a/toolchains/nodejs/docs/BUILD.bazel
+++ b/toolchains/nodejs/docs/BUILD.bazel
@@ -3,6 +3,9 @@ load("@rules_nixpkgs_docs//:stardoc.bzl", "generate_documentation")
 generate_documentation(
     name = "README.md",
     input = "//:nodejs.bzl",
-    symbol_names = ["nixpkgs_nodejs_configure"],
+    symbol_names = [
+        "nixpkgs_nodejs_configure",
+        "nixpkgs_nodejs_configure_platforms",
+    ],
     deps = ["//:nodejs"],
 )

--- a/toolchains/nodejs/nodejs.bzl
+++ b/toolchains/nodejs/nodejs.bzl
@@ -130,12 +130,43 @@ def nixpkgs_nodejs_configure(
 def nixpkgs_nodejs_configure_platforms(
   name = "nixpkgs_nodejs",
   platforms_mapping = DEFAULT_PLATFORMS_MAPPING,
+  attribute_path = "nodejs",
+  repository = None,
+  repositories = {},
+  nix_platform = None,
+  nix_file = None,
+  nix_file_content = None,
+  nix_file_deps = None,
+  nixopts = [],
+  fail_not_supported = True,
+  quiet = False,
+  exec_constraints = None,
+  target_constraints = None,
   **kwargs,
 ):
+    """Runs nixpkgs_nodejs_configure for each platform.
+
+    Since rules_nodejs adds platform suffix to repository name, this can be helpful
+    if one wants to use npm_install and reference js dependencies from npm repo.
+    See the example directory.
+
+    Args:
+      platforms_mapping: struct describing mapping between nix platform and rules_nodejs bazel platform with
+        target and exec constraints
+    """
     for nix_platform, bazel_platform in platforms_mapping.items():
         nixpkgs_nodejs_configure(
             name = "{}_{}".format(name, bazel_platform.rules_nodejs_platform),
+            attribute_path = attribute_path,
+            repository = repository,
+            repositories = repositories,
             nix_platform = nix_platform,
+            nix_file = nix_file,
+            nix_file_content = nix_file_content,
+            nix_file_deps = nix_file_deps,
+            nixopts = nixopts,
+            fail_not_supported = fail_not_supported,
+            quiet = quiet,
             exec_constraints = bazel_platform.exec_constraints,
             target_constraints = bazel_platform.target_constraints,
             **kwargs,

--- a/toolchains/nodejs/nodejs.bzl
+++ b/toolchains/nodejs/nodejs.bzl
@@ -1,5 +1,6 @@
 load("@rules_nixpkgs_core//:nixpkgs.bzl", "nixpkgs_package")
 load("@rules_nixpkgs_core//:util.bzl", "ensure_constraints")
+load("@rules_nodejs//nodejs:repositories.bzl", "BUILT_IN_NODE_PLATFORMS")
 
 _nodejs_nix_content = """\
 let
@@ -105,3 +106,13 @@ def nixpkgs_nodejs_configure(
     )
 
     native.register_toolchains("@{}_toolchain//:nodejs_nix".format(name))
+
+def nixpkgs_nodejs_configure_platforms(
+  name = "nixpkgs_nodejs",
+  **kwargs,
+):
+    for platform in BUILT_IN_NODE_PLATFORMS:
+        nixpkgs_nodejs_configure(
+            name = "{}_{}".format(name, platform),
+            **kwargs,
+        )

--- a/toolchains/nodejs/nodejs.bzl
+++ b/toolchains/nodejs/nodejs.bzl
@@ -1,10 +1,20 @@
 load("@rules_nixpkgs_core//:nixpkgs.bzl", "nixpkgs_package")
 load("@rules_nixpkgs_core//:util.bzl", "ensure_constraints")
-load("@rules_nodejs//nodejs:repositories.bzl", "BUILT_IN_NODE_PLATFORMS")
+load("@rules_nodejs//nodejs/private:toolchains_repo.bzl", "PLATFORMS")
+
+# obtained (and matched) from:
+# nixpkgs search: https://search.nixos.org/packages?channel=22.11&show=nodejs&from=0&size=50&sort=relevance&type=packages&query=nodejs
+# rules_nodejs: https://github.com/bazelbuild/rules_nodejs/blob/a5755eb458c2dd8e0e2cf9b92d8304d9e77ea117/nodejs/private/toolchains_repo.bzl#L20
+_nodejs_nix_to_bazel_platforms_map = {
+    "aarch64-darwin": "darwin_arm64",
+    "x86_64-linux": "linux_amd64",
+    "x86_64-darwin": "darwin_amd64",
+    "aarch64-linux": "linux_arm64",
+}
 
 _nodejs_nix_content = """\
 let
-    pkgs = import <nixpkgs> {{ config = {{}}; overlays = []; }};
+    pkgs = import <nixpkgs> {{ config = {{}}; overlays = []; system = {nix_platform}; }};
     nodejs = pkgs.{attribute_path};
 in
 pkgs.buildEnv {{
@@ -69,6 +79,7 @@ def nixpkgs_nodejs_configure(
   attribute_path = "nodejs",
   repository = None,
   repositories = {},
+  nix_platform = None,
   nix_file = None,
   nix_file_content = None,
   nix_file_deps = None,
@@ -80,10 +91,12 @@ def nixpkgs_nodejs_configure(
 ):
     if attribute_path == None:
         fail("'attribute_path' is required.", "attribute_path")
-
+    if (nix_platform != None and nix_platform not in _nodejs_nix_to_bazel_platforms_map.keys()):
+        fail("'nix_platform' ({}) not supported.".format(repr(nix_platform)), "nix_platform")
     if not nix_file and not nix_file_content:
       nix_file_content = _nodejs_nix_content.format(
         attribute_path = attribute_path,
+        nix_platform = repr(nix_platform) if nix_platform in _nodejs_nix_to_bazel_platforms_map else "builtins.currentSystem",
       )
 
     nixpkgs_package(
@@ -111,8 +124,13 @@ def nixpkgs_nodejs_configure_platforms(
   name = "nixpkgs_nodejs",
   **kwargs,
 ):
-    for platform in BUILT_IN_NODE_PLATFORMS:
+    for nix_platform, bazel_platform in _nodejs_nix_to_bazel_platforms_map.items():
+        # get the constaints defined under rules_nodejs PLATFORMS variable
+        constraints = PLATFORMS[bazel_platform].compatible_with
         nixpkgs_nodejs_configure(
-            name = "{}_{}".format(name, platform),
+            name = "{}_{}".format(name, bazel_platform),
+            nix_platform = nix_platform,
+            exec_constraints = constraints,
+            target_constraints = constraints,
             **kwargs,
         )

--- a/toolchains/nodejs/nodejs.bzl
+++ b/toolchains/nodejs/nodejs.bzl
@@ -88,7 +88,7 @@ def nixpkgs_nodejs_configure(
   attribute_path = "nodejs",
   repository = None,
   repositories = {},
-  nix_platform = "builtins.currentSystem",
+  nix_platform = None,
   nix_file = None,
   nix_file_content = None,
   nix_file_deps = None,
@@ -100,14 +100,10 @@ def nixpkgs_nodejs_configure(
 ):
     if attribute_path == None:
         fail("'attribute_path' is required.", "attribute_path")
-    if (nix_platform == None):
-        fail("'nix_platform' is required.", "attribute_path")
     if not nix_file and not nix_file_content:
-      if (nix_platform == None):
-        fail("'nix_platform' is required.", "attribute_path")
       nix_file_content = _nodejs_nix_content.format(
         attribute_path = attribute_path,
-        nix_platform = repr(nix_platform),
+        nix_platform = "builtins.currentSystem" if nix_platform == None else repr(nix_platform),
       )
 
     nixpkgs_package(


### PR DESCRIPTION
While applying latest `rules_nodejs`(`5.8.0`) to one of the projects I'm working on, I saw there's no longer an option to pass `vendored_node` to `npm_install` rule.

Following [this "migration guide"](https://github.com/bazelbuild/rules_nodejs/wiki/Migrating-to-5.0) it was found out (thx @avdv @aherrmann ) that using proper `npm_install::node_reporitory` value does the job.

However there's an issue of suffixing toolchain names which rules_nodejs does - see `nixpkgs-nodejs_linux_amd64` as one of the names. E.g. now macos build fails with:
```
Error in path: Unable to load package for @nixpkgs-nodejs_darwin_amd64//:bin/node: The repository '@nixpkgs-nodejs_darwin_amd64' could not be resolved: Repository '@nixpkgs-nodejs_darwin_amd64' is not defined
```

Probably we have to mimic the behavior that [rules_haskell does](https://github.com/tweag/rules_haskell/blob/8e0189dc8b444f81ff33e5f69ae4489cb342bab6/haskell/asterius/asterius_dependencies.bzl#L96-L113) (thx @ylecornec )