### PR TITLE
Update to Bazel version 6 and nixpkgs 22.11

### DIFF
--- a/examples/python-container/nixpkgs.json
+++ b/examples/python-container/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "branch": "22.05",
-  "rev": "ce6aa13369b667ac2542593170993504932eb836",
-  "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik"
+  "branch": "22.11",
+  "rev": "f413457e0dd7a42adefdbcea4391dd9751509025",
+  "sha256": "sha256-F7/F65ZFWbq7cKSiV3K2acxCv64jKaZZ/K0A3VNT2kA="
 }

--- a/examples/python-container/shell.nix
+++ b/examples/python-container/shell.nix
@@ -2,7 +2,7 @@
 
 pkgs.mkShellNoCC {
     nativeBuildInputs = [
-       pkgs.bazel_5
+       pkgs.bazel_6
     ];
 }
 

--- a/examples/toolchains/cc/nixpkgs.json
+++ b/examples/toolchains/cc/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "branch": "22.05",
-  "rev": "ce6aa13369b667ac2542593170993504932eb836",
-  "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik"
+  "branch": "22.11",
+  "rev": "f413457e0dd7a42adefdbcea4391dd9751509025",
+  "sha256": "sha256-F7/F65ZFWbq7cKSiV3K2acxCv64jKaZZ/K0A3VNT2kA="
 }

--- a/examples/toolchains/cc/nixpkgs.nix
+++ b/examples/toolchains/cc/nixpkgs.nix
@@ -1,5 +1,4 @@
 let
-  # nixpkgs 21.11
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/examples/toolchains/cc/shell.nix
+++ b/examples/toolchains/cc/shell.nix
@@ -1,3 +1,3 @@
 { pkgs ? import ./nixpkgs.nix { } }:
 
-pkgs.mkShellNoCC { nativeBuildInputs = [ pkgs.bazel_5 ]; }
+pkgs.mkShellNoCC { nativeBuildInputs = [ pkgs.bazel_6 ]; }

--- a/examples/toolchains/cc_with_deps/nixpkgs.json
+++ b/examples/toolchains/cc_with_deps/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "branch": "22.05",
-  "rev": "ce6aa13369b667ac2542593170993504932eb836",
-  "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik"
+  "branch": "22.11",
+  "rev": "f413457e0dd7a42adefdbcea4391dd9751509025",
+  "sha256": "sha256-F7/F65ZFWbq7cKSiV3K2acxCv64jKaZZ/K0A3VNT2kA="
 }

--- a/examples/toolchains/cc_with_deps/nixpkgs.nix
+++ b/examples/toolchains/cc_with_deps/nixpkgs.nix
@@ -1,5 +1,4 @@
 let
-  # nixpkgs 21.11
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/examples/toolchains/cc_with_deps/shell.nix
+++ b/examples/toolchains/cc_with_deps/shell.nix
@@ -1,3 +1,3 @@
 { pkgs ? import ./nixpkgs.nix { } }:
 
-pkgs.mkShellNoCC { nativeBuildInputs = [ pkgs.bazel_5 ]; }
+pkgs.mkShellNoCC { nativeBuildInputs = [ pkgs.bazel_6 ]; }

--- a/examples/toolchains/go/nixpkgs.json
+++ b/examples/toolchains/go/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "branch": "22.05",
-  "rev": "ce6aa13369b667ac2542593170993504932eb836",
-  "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik"
+  "branch": "22.11",
+  "rev": "f413457e0dd7a42adefdbcea4391dd9751509025",
+  "sha256": "sha256-F7/F65ZFWbq7cKSiV3K2acxCv64jKaZZ/K0A3VNT2kA="
 }

--- a/examples/toolchains/go/nixpkgs.nix
+++ b/examples/toolchains/go/nixpkgs.nix
@@ -1,5 +1,4 @@
 let
-  # nixpkgs 21.11
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/examples/toolchains/go/shell.nix
+++ b/examples/toolchains/go/shell.nix
@@ -1,3 +1,3 @@
 { pkgs ? import ./nixpkgs.nix { } }:
 
-pkgs.mkShellNoCC { nativeBuildInputs = [ pkgs.bazel_5 ]; }
+pkgs.mkShellNoCC { nativeBuildInputs = [ pkgs.bazel_6 ]; }

--- a/examples/toolchains/java/nixpkgs.json
+++ b/examples/toolchains/java/nixpkgs.json
@@ -1,8 +1,8 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "branch": "22.05",
-  "rev": "ce6aa13369b667ac2542593170993504932eb836",
-  "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik"
+  "branch": "22.11",
+  "rev": "f413457e0dd7a42adefdbcea4391dd9751509025",
+  "sha256": "sha256-F7/F65ZFWbq7cKSiV3K2acxCv64jKaZZ/K0A3VNT2kA="
 }
 

--- a/examples/toolchains/java/shell.nix
+++ b/examples/toolchains/java/shell.nix
@@ -1,3 +1,3 @@
 { pkgs ? import ./nixpkgs.nix { } }:
 
-pkgs.mkShellNoCC { nativeBuildInputs = [ pkgs.bazel_5 ]; }
+pkgs.mkShellNoCC { nativeBuildInputs = [ pkgs.bazel_6 ]; }

--- a/examples/toolchains/nodejs/nixpkgs.json
+++ b/examples/toolchains/nodejs/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "branch": "22.05",
-  "rev": "ce6aa13369b667ac2542593170993504932eb836",
-  "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik"
+  "branch": "22.11",
+  "rev": "f413457e0dd7a42adefdbcea4391dd9751509025",
+  "sha256": "sha256-F7/F65ZFWbq7cKSiV3K2acxCv64jKaZZ/K0A3VNT2kA="
 }

--- a/examples/toolchains/nodejs/nixpkgs.nix
+++ b/examples/toolchains/nodejs/nixpkgs.nix
@@ -1,5 +1,4 @@
 let
-  # nixpkgs 21.11
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/examples/toolchains/nodejs/shell.nix
+++ b/examples/toolchains/nodejs/shell.nix
@@ -1,3 +1,3 @@
 { pkgs ? import ./nixpkgs.nix { } }:
 
-pkgs.mkShellNoCC { nativeBuildInputs = [ pkgs.bazel_5 ]; }
+pkgs.mkShellNoCC { nativeBuildInputs = [ pkgs.bazel_6 ]; }

--- a/examples/toolchains/python/nixpkgs.json
+++ b/examples/toolchains/python/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "branch": "22.05",
-  "rev": "ce6aa13369b667ac2542593170993504932eb836",
-  "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik"
+  "branch": "22.11",
+  "rev": "f413457e0dd7a42adefdbcea4391dd9751509025",
+  "sha256": "sha256-F7/F65ZFWbq7cKSiV3K2acxCv64jKaZZ/K0A3VNT2kA="
 }

--- a/examples/toolchains/python/nixpkgs.nix
+++ b/examples/toolchains/python/nixpkgs.nix
@@ -1,5 +1,4 @@
 let
-  # nixpkgs 21.11
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/examples/toolchains/python/shell.nix
+++ b/examples/toolchains/python/shell.nix
@@ -1,3 +1,3 @@
 { pkgs ? import ./nixpkgs.nix { } }:
 
-pkgs.mkShellNoCC { nativeBuildInputs = [ pkgs.bazel_5 ]; }
+pkgs.mkShellNoCC { nativeBuildInputs = [ pkgs.bazel_6 ]; }

--- a/examples/toolchains/rust/nixpkgs.nix
+++ b/examples/toolchains/rust/nixpkgs.nix
@@ -1,5 +1,4 @@
 let
-  # nixpkgs 21.11
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
   nixpkgs = fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";

--- a/examples/toolchains/rust/shell.nix
+++ b/examples/toolchains/rust/shell.nix
@@ -1,6 +1,6 @@
 { pkgs ? import ./nixpkgs.nix { } }:
 with pkgs;
 mkShell {
-  nativeBuildInputs = [ bazel_5 git nix zlib libiconv ]
+  nativeBuildInputs = [ bazel_6 git nix zlib libiconv ]
     ++ (lib.optional stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ]);
 }

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
       {
         devShells.default = with pkgs; mkShell {
           name = "rules_nixpkgs_shell";
-          packages = [ bazel_5 bazel-buildtools cacert gcc nix git ];
+          packages = [ bazel_6 bazel-buildtools cacert gcc nix git ];
         };
       });
 }

--- a/toolchains/go/WORKSPACE
+++ b/toolchains/go/WORKSPACE
@@ -31,7 +31,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "",
+    sha256 = "685052b498b6ddfe562ca7a97736741d87916fe536623afb7da2824c0211c369",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
         "https://github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",


### PR DESCRIPTION
Update nixpkgs to 22.11 and Bazel to version 6 in the top-level workspace and the example workspaces.

Also sets the missing sha256 on the rules_go import in toolchains/go.
