### PR TITLE
Update `nixpkgs_cc_configure` to work without `nix_file` or `nix_content`

### DIFF
--- a/examples/toolchains/cc/WORKSPACE
+++ b/examples/toolchains/cc/WORKSPACE
@@ -33,6 +33,7 @@ nixpkgs_git_repository(
 nixpkgs_cc_configure(
     name = "nixpkgs_config_cc",
     repository = "@nixpkgs",
+    attribute_path = "clang_13",
 )
 
 load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies", "rules_cc_toolchains")

--- a/toolchains/cc/README.md
+++ b/toolchains/cc/README.md
@@ -71,6 +71,13 @@ nixpkgs_cc_configure(
 )
 ```
 ```
+# alternate usage without specifying `nix_file` or `nix_file_content`
+nixpkgs_cc_configure(
+  repository = "@nixpkgs",
+  attribute_path = "gcc11",
+)
+```
+```
 # use the `stdenv.cc` compiler (the default of the given @nixpkgs repository)
 nixpkgs_cc_configure(
   repository = "@nixpkgs",
@@ -110,7 +117,7 @@ default is <code>""</code>
 
 <p>
 
-optional, string, Obtain the toolchain from the Nix expression under this attribute path. Requires `nix_file` or `nix_file_content`.
+optional, string, Obtain the toolchain from the Nix expression under this attribute path. Uses default repository if no `nix_file` or `nix_file_content` is provided.
 
 </p>
 </td>

--- a/toolchains/cc/cc.bzl
+++ b/toolchains/cc/cc.bzl
@@ -342,6 +342,13 @@ def nixpkgs_cc_configure(
     )
     ```
     ```
+    # alternate usage without specifying `nix_file` or `nix_file_content`
+    nixpkgs_cc_configure(
+      repository = "@nixpkgs",
+      attribute_path = "gcc11",
+    )
+    ```
+    ```
     # use the `stdenv.cc` compiler (the default of the given @nixpkgs repository)
     nixpkgs_cc_configure(
       repository = "@nixpkgs",
@@ -355,7 +362,7 @@ def nixpkgs_cc_configure(
     this toolchain.
 
     Args:
-      attribute_path: optional, string, Obtain the toolchain from the Nix expression under this attribute path. Requires `nix_file` or `nix_file_content`.
+      attribute_path: optional, string, Obtain the toolchain from the Nix expression under this attribute path. Uses default repository if no `nix_file` or `nix_file_content` is provided.
       nix_file: optional, Label, Obtain the toolchain from the Nix expression defined in this file. Specify only one of `nix_file` or `nix_file_content`.
       nix_file_content: optional, string, Obtain the toolchain from the given Nix expression. Specify only one of `nix_file` or `nix_file_content`.
       nix_file_deps: optional, list of Label, Additional files that the Nix expression depends on.
@@ -381,10 +388,11 @@ def nixpkgs_cc_configure(
         nix_file_deps.append(nix_file)
     elif nix_file_content:
         nix_expr = nix_file_content
-
-    if attribute_path and nix_expr == None:
-        fail("'attribute_path' requires one of 'nix_file' or 'nix_file_content'", "attribute_path")
     elif attribute_path:
+        nix_expr = "(import <nixpkgs> {{}}).{0}".format(attribute_path)
+        attribute_path = None
+
+    if attribute_path:
         nixopts.extend([
             "--argstr",
             "ccType",


### PR DESCRIPTION
The simple example for the cc toolchain was updated to showcase the usage. I'm not sure if this should have a separate test altogether.

Related issue: #328