### PR TITLE
Fix arguments in cc_configure

### DIFF
--- a/toolchains/cc/README.md
+++ b/toolchains/cc/README.md
@@ -10,7 +10,7 @@ One may wish to use a C++ toolchain to compile certain libraries written in
 non-C++ languages. For instance, Clang/LLVM can be used to compile CUDA or HIP
 code targeting GPUs. This can be achieved by:
 
-  1. passing `cc_lang = "none"` in `nixpkgs_cc_configure` below 
+  1. passing `cc_lang = "none"` in `nixpkgs_cc_configure` below
   2. using a rule invocation of the form `cc_library(..., copts="-x cuda")`
   when defining individual libraries or executables
 

--- a/toolchains/cc/cc.bzl
+++ b/toolchains/cc/cc.bzl
@@ -8,7 +8,7 @@ One may wish to use a C++ toolchain to compile certain libraries written in
 non-C++ languages. For instance, Clang/LLVM can be used to compile CUDA or HIP
 code targeting GPUs. This can be achieved by:
 
-  1. passing `cc_lang = "none"` in `nixpkgs_cc_configure` below 
+  1. passing `cc_lang = "none"` in `nixpkgs_cc_configure` below
   2. using a rule invocation of the form `cc_library(..., copts="-x cuda")`
   when defining individual libraries or executables
 
@@ -403,7 +403,7 @@ def nixpkgs_cc_configure(
             "--arg",
             "ccAttrSet",
             nix_expr,
-            "--arg",
+            "--argstr",
             "ccLang",
             cc_lang,
         ])
@@ -415,12 +415,18 @@ def nixpkgs_cc_configure(
             "--arg",
             "ccExpr",
             nix_expr,
+            "--argstr",
+            "ccLang",
+            cc_lang,
         ])
     else:
         nixopts.extend([
             "--argstr",
             "ccType",
             "ccTypeDefault",
+            "--argstr",
+            "ccLang",
+            cc_lang,
         ])
 
     # Invoke `cc.nix` which generates `CC_TOOLCHAIN_INFO`.


### PR DESCRIPTION
--arg must be argstr to allow for arguments such as 'c++'
More over, allow for ccLang to be passed any path. Only prescribing attribute path is undocumented, and unexpected