### PR TITLE
Implement remaining nix_repo tags

### DIFF
--- a/core/extensions/repository.bzl
+++ b/core/extensions/repository.bzl
@@ -86,6 +86,7 @@ def _expr_repo(expr):
     return partial.make(
         nixpkgs_local_repository,
         nix_file_content = expr.expr,
+        nix_file_deps = expr.file_deps,
     )
 
 def _nix_repo_impl(module_ctx):
@@ -225,15 +226,18 @@ _HTTP_ATTRS = {
     ),
 }
 
+_FILE_DEPS_ATTRS = {
+    "file_deps": attr.label_list(
+        doc = "List of files required by the Nix expression.",
+        mandatory = False,
+    ),
+}
+
 _FILE_ATTRS = {
     "file": attr.label(
         doc = "The file containing the Nix expression.",
         mandatory = True,
         allow_single_file = True,
-    ),
-    "file_deps": attr.label_list(
-        doc = "List of files required by the Nix expression.",
-        mandatory = False,
     ),
 }
 
@@ -267,12 +271,12 @@ _http_tag = tag_class(
 )
 
 _file_tag = tag_class(
-    attrs = dicts.add(_NAME_ATTRS, _FILE_ATTRS),
+    attrs = dicts.add(_NAME_ATTRS, _FILE_ATTRS, _FILE_DEPS_ATTRS),
     doc = "Import a Nix repository from a local file.",
 )
 
 _expr_tag = tag_class(
-    attrs = dicts.add(_NAME_ATTRS, _EXPR_ATTRS),
+    attrs = dicts.add(_NAME_ATTRS, _EXPR_ATTRS, _FILE_DEPS_ATTRS),
     doc = "Import a Nix repository from a Nix expression.",
 )
 

--- a/design/bzlmod/README.md
+++ b/design/bzlmod/README.md
@@ -518,6 +518,7 @@ offers tags to define Nix repositories:
 * `expr(name, expression)`\
   * `name`: `String`; unique name.
   * `expr`: `String`; the Nix expression.
+  * `file_deps`: optional, List of `Label`, files required by `expr`.
 * `override(repo)` (only allowed in rules\_nixpkgs\_core and root)\
   * `repo`: `String`; The name of the repository to override.
 

--- a/design/bzlmod/README.md
+++ b/design/bzlmod/README.md
@@ -517,7 +517,7 @@ offers tags to define Nix repositories:
   * `file_deps`: optional, List of `Label`, files required by `file`.
 * `expr(name, expression)`\
   * `name`: `String`; unique name.
-  * `expression`: `String`; the Nix expression.
+  * `expr`: `String`; the Nix expression.
 * `override(repo)` (only allowed in rules\_nixpkgs\_core and root)\
   * `repo`: `String`; The name of the repository to override.
 

--- a/testing/core/MODULE.bazel
+++ b/testing/core/MODULE.bazel
@@ -22,6 +22,12 @@ nix_repo.github(
     tag = "22.05",
     sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
 )
+nix_repo.http(
+    name = "http_nixpkgs",
+    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/22.05.tar.gz",
+    sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
+    strip_prefix = "nixpkgs-22.05",
+)
 
 nix_pkg = use_extension("@rules_nixpkgs_core//extensions:package.bzl", "nix_pkg")
 use_repo(nix_pkg, "nixpkgs_packages")
@@ -30,7 +36,6 @@ nix_pkg.local_attr(name = "attribute-test", attr = "hello")
 nix_pkg.local_attr(name = "nixpkgs-git-repository-test", attr = "hello", repo = "remote_nixpkgs")
 
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
-use_repo(non_module_deps, "http_nixpkgs")
 use_repo(non_module_deps, "nixpkgs_content")
 use_repo(non_module_deps, "expr-test")
 use_repo(non_module_deps, "expr-attribute-test")

--- a/testing/core/MODULE.bazel
+++ b/testing/core/MODULE.bazel
@@ -28,6 +28,13 @@ nix_repo.http(
     sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
     strip_prefix = "nixpkgs-22.05",
 )
+nix_repo.file(
+    name = "nixpkgs_content",
+    file = "//:nixpkgs.nix",
+    file_deps = [
+        "//:flake.lock",
+    ],
+)
 
 nix_pkg = use_extension("@rules_nixpkgs_core//extensions:package.bzl", "nix_pkg")
 use_repo(nix_pkg, "nixpkgs_packages")
@@ -36,7 +43,6 @@ nix_pkg.local_attr(name = "attribute-test", attr = "hello")
 nix_pkg.local_attr(name = "nixpkgs-git-repository-test", attr = "hello", repo = "remote_nixpkgs")
 
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
-use_repo(non_module_deps, "nixpkgs_content")
 use_repo(non_module_deps, "expr-test")
 use_repo(non_module_deps, "expr-attribute-test")
 use_repo(non_module_deps, "extra-args-test")

--- a/testing/core/MODULE.bazel
+++ b/testing/core/MODULE.bazel
@@ -29,7 +29,7 @@ nix_repo.http(
     strip_prefix = "nixpkgs-22.05",
 )
 nix_repo.file(
-    name = "nixpkgs_content",
+    name = "file_nixpkgs",
     file = "//:nixpkgs.nix",
     file_deps = [
         "//:flake.lock",
@@ -43,12 +43,14 @@ nix_pkg.local_attr(name = "attribute-test", attr = "hello")
 nix_pkg.local_attr(name = "nixpkgs-git-repository-test", attr = "hello", repo = "remote_nixpkgs")
 
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
+use_repo(non_module_deps, "nixpkgs_content")
 use_repo(non_module_deps, "expr-test")
 use_repo(non_module_deps, "expr-attribute-test")
 use_repo(non_module_deps, "extra-args-test")
 use_repo(non_module_deps, "nix-file-test")
 use_repo(non_module_deps, "nix-file-deps-test")
 use_repo(non_module_deps, "nixpkgs-http-repository-test")
+use_repo(non_module_deps, "nixpkgs-file-repository-test")
 use_repo(non_module_deps, "nixpkgs-local-repository-test")
 use_repo(non_module_deps, "relative-imports")
 use_repo(non_module_deps, "output-filegroup-test")

--- a/testing/core/MODULE.bazel
+++ b/testing/core/MODULE.bazel
@@ -35,6 +35,14 @@ nix_repo.file(
         "//:flake.lock",
     ],
 )
+nix_repo.expr(
+    name = "nixpkgs_content",
+    expr = "import ./nixpkgs.nix",
+    file_deps = [
+        "//:nixpkgs.nix",
+        "//:flake.lock",
+    ],
+)
 
 nix_pkg = use_extension("@rules_nixpkgs_core//extensions:package.bzl", "nix_pkg")
 use_repo(nix_pkg, "nixpkgs_packages")
@@ -43,7 +51,6 @@ nix_pkg.local_attr(name = "attribute-test", attr = "hello")
 nix_pkg.local_attr(name = "nixpkgs-git-repository-test", attr = "hello", repo = "remote_nixpkgs")
 
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
-use_repo(non_module_deps, "nixpkgs_content")
 use_repo(non_module_deps, "expr-test")
 use_repo(non_module_deps, "expr-attribute-test")
 use_repo(non_module_deps, "extra-args-test")

--- a/testing/core/tests/BUILD.bazel
+++ b/testing/core/tests/BUILD.bazel
@@ -41,6 +41,7 @@ expand_location_unit_test_suite()
         "nix-file-test",
         "nix-file-deps-test",
         "nixpkgs-http-repository-test",
+        "nixpkgs-file-repository-test",
         "nixpkgs-local-repository-test",
         "relative-imports",
     ]

--- a/testing/core/tests/nixpkgs_repositories.bzl
+++ b/testing/core/tests/nixpkgs_repositories.bzl
@@ -12,6 +12,7 @@ def nixpkgs_repositories(*, bzlmod):
     if bzlmod:
         nixpkgs = nix_repo("rules_nixpkgs_core_testing", "nixpkgs")
         remote_nixpkgs = nix_repo("rules_nixpkgs_core_testing", "remote_nixpkgs")
+        http_nixpkgs = nix_repo("rules_nixpkgs_core_testing", "http_nixpkgs")
     else:
         nixpkgs = "@nixpkgs"
         nixpkgs_local_repository(
@@ -25,6 +26,14 @@ def nixpkgs_repositories(*, bzlmod):
             name = "remote_nixpkgs",
             remote = "https://github.com/NixOS/nixpkgs",
             revision = "22.05",
+            sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
+        )
+
+        http_nixpkgs = "@http_nixpkgs"
+        nixpkgs_http_repository(
+            name = "http_nixpkgs",
+            url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/22.05.tar.gz",
+            strip_prefix = "nixpkgs-22.05",
             sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
         )
 
@@ -45,13 +54,6 @@ def nixpkgs_repositories(*, bzlmod):
             attribute_path = "hello",
             repositories = {"nixpkgs": remote_nixpkgs},
         )
-
-    nixpkgs_http_repository(
-        name = "http_nixpkgs",
-        url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/22.05.tar.gz",
-        strip_prefix = "nixpkgs-22.05",
-        sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
-    )
 
     # same as @nixpkgs but using the `nix_file_content` parameter
     nixpkgs_local_repository(
@@ -108,7 +110,7 @@ def nixpkgs_repositories(*, bzlmod):
     nixpkgs_package(
         name = "nixpkgs-http-repository-test",
         attribute_path = "hello",
-        repositories = {"nixpkgs": "@http_nixpkgs"},
+        repositories = {"nixpkgs": http_nixpkgs},
     )
 
     nixpkgs_package(

--- a/testing/core/tests/nixpkgs_repositories.bzl
+++ b/testing/core/tests/nixpkgs_repositories.bzl
@@ -13,6 +13,7 @@ def nixpkgs_repositories(*, bzlmod):
         nixpkgs = nix_repo("rules_nixpkgs_core_testing", "nixpkgs")
         remote_nixpkgs = nix_repo("rules_nixpkgs_core_testing", "remote_nixpkgs")
         http_nixpkgs = nix_repo("rules_nixpkgs_core_testing", "http_nixpkgs")
+        nixpkgs_content = nix_repo("rules_nixpkgs_core_testing", "nixpkgs_content")
     else:
         nixpkgs = "@nixpkgs"
         nixpkgs_local_repository(
@@ -37,6 +38,17 @@ def nixpkgs_repositories(*, bzlmod):
             sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
         )
 
+        # same as @nixpkgs but using the `nix_file_content` parameter
+        nixpkgs_content = "@nixpkgs_content"
+        nixpkgs_local_repository(
+            name = "nixpkgs_content",
+            nix_file_content = "import ./nixpkgs.nix",
+            nix_file_deps = [
+                "//:nixpkgs.nix",
+                "//:flake.lock",
+            ],
+        )
+
         nixpkgs_package(
             name = "hello",
             # Deliberately not repository, to test whether repositories works.
@@ -54,16 +66,6 @@ def nixpkgs_repositories(*, bzlmod):
             attribute_path = "hello",
             repositories = {"nixpkgs": remote_nixpkgs},
         )
-
-    # same as @nixpkgs but using the `nix_file_content` parameter
-    nixpkgs_local_repository(
-        name = "nixpkgs_content",
-        nix_file_content = "import ./nixpkgs.nix",
-        nix_file_deps = [
-            "//:nixpkgs.nix",
-            "//:flake.lock",
-        ],
-    )
 
     nixpkgs_package(
         name = "expr-test",
@@ -116,7 +118,7 @@ def nixpkgs_repositories(*, bzlmod):
     nixpkgs_package(
         name = "nixpkgs-local-repository-test",
         nix_file_content = "with import <nixpkgs> {}; hello",
-        repositories = {"nixpkgs": "@nixpkgs_content"},
+        repositories = {"nixpkgs": nixpkgs_content},
     )
 
     nixpkgs_package(

--- a/testing/core/tests/nixpkgs_repositories.bzl
+++ b/testing/core/tests/nixpkgs_repositories.bzl
@@ -13,7 +13,7 @@ def nixpkgs_repositories(*, bzlmod):
         nixpkgs = nix_repo("rules_nixpkgs_core_testing", "nixpkgs")
         remote_nixpkgs = nix_repo("rules_nixpkgs_core_testing", "remote_nixpkgs")
         http_nixpkgs = nix_repo("rules_nixpkgs_core_testing", "http_nixpkgs")
-        nixpkgs_content = nix_repo("rules_nixpkgs_core_testing", "nixpkgs_content")
+        file_nixpkgs = nix_repo("rules_nixpkgs_core_testing", "file_nixpkgs")
     else:
         nixpkgs = "@nixpkgs"
         nixpkgs_local_repository(
@@ -38,15 +38,12 @@ def nixpkgs_repositories(*, bzlmod):
             sha256 = "0f8c25433a6611fa5664797cd049c80faefec91575718794c701f3b033f2db01",
         )
 
-        # same as @nixpkgs but using the `nix_file_content` parameter
-        nixpkgs_content = "@nixpkgs_content"
+        # same as @nixpkgs, only needed for bzlmod tests to distinguish `default` and `file`.
+        file_nixpkgs = "@file_nixpkgs"
         nixpkgs_local_repository(
-            name = "nixpkgs_content",
-            nix_file_content = "import ./nixpkgs.nix",
-            nix_file_deps = [
-                "//:nixpkgs.nix",
-                "//:flake.lock",
-            ],
+            name = "file_nixpkgs",
+            nix_file = "//:nixpkgs.nix",
+            nix_file_deps = ["//:flake.lock"],
         )
 
         nixpkgs_package(
@@ -66,6 +63,17 @@ def nixpkgs_repositories(*, bzlmod):
             attribute_path = "hello",
             repositories = {"nixpkgs": remote_nixpkgs},
         )
+
+    # same as @nixpkgs but using the `nix_file_content` parameter
+    nixpkgs_content = "@nixpkgs_content"
+    nixpkgs_local_repository(
+        name = "nixpkgs_content",
+        nix_file_content = "import ./nixpkgs.nix",
+        nix_file_deps = [
+            "//:nixpkgs.nix",
+            "//:flake.lock",
+        ],
+    )
 
     nixpkgs_package(
         name = "expr-test",
@@ -113,6 +121,12 @@ def nixpkgs_repositories(*, bzlmod):
         name = "nixpkgs-http-repository-test",
         attribute_path = "hello",
         repositories = {"nixpkgs": http_nixpkgs},
+    )
+
+    nixpkgs_package(
+        name = "nixpkgs-file-repository-test",
+        nix_file_content = "with import <nixpkgs> {}; hello",
+        repositories = {"nixpkgs": file_nixpkgs},
     )
 
     nixpkgs_package(

--- a/testing/core/tests/nixpkgs_repositories.bzl
+++ b/testing/core/tests/nixpkgs_repositories.bzl
@@ -14,6 +14,7 @@ def nixpkgs_repositories(*, bzlmod):
         remote_nixpkgs = nix_repo("rules_nixpkgs_core_testing", "remote_nixpkgs")
         http_nixpkgs = nix_repo("rules_nixpkgs_core_testing", "http_nixpkgs")
         file_nixpkgs = nix_repo("rules_nixpkgs_core_testing", "file_nixpkgs")
+        nixpkgs_content = nix_repo("rules_nixpkgs_core_testing", "nixpkgs_content")
     else:
         nixpkgs = "@nixpkgs"
         nixpkgs_local_repository(
@@ -46,6 +47,17 @@ def nixpkgs_repositories(*, bzlmod):
             nix_file_deps = ["//:flake.lock"],
         )
 
+        # same as @nixpkgs but using the `nix_file_content` parameter
+        nixpkgs_content = "@nixpkgs_content"
+        nixpkgs_local_repository(
+            name = "nixpkgs_content",
+            nix_file_content = "import ./nixpkgs.nix",
+            nix_file_deps = [
+                "//:nixpkgs.nix",
+                "//:flake.lock",
+            ],
+        )
+
         nixpkgs_package(
             name = "hello",
             # Deliberately not repository, to test whether repositories works.
@@ -63,17 +75,6 @@ def nixpkgs_repositories(*, bzlmod):
             attribute_path = "hello",
             repositories = {"nixpkgs": remote_nixpkgs},
         )
-
-    # same as @nixpkgs but using the `nix_file_content` parameter
-    nixpkgs_content = "@nixpkgs_content"
-    nixpkgs_local_repository(
-        name = "nixpkgs_content",
-        nix_file_content = "import ./nixpkgs.nix",
-        nix_file_deps = [
-            "//:nixpkgs.nix",
-            "//:flake.lock",
-        ],
-    )
 
     nixpkgs_package(
         name = "expr-test",


### PR DESCRIPTION
Part of #183.

Implement the remaining `http`, `file`, and `expr` tags for `nix_repo`.
Ensure each of them is tested in `testing/core`.


