### PR TITLE
Set -Wno-elaborated-enum-base on Darwin

### DIFF
--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -32,6 +32,7 @@ let
       bintools = pkgs.stdenv.cc.bintools.override { inherit postLinkSignHook; };
       extraBuildCommands = with pkgs.darwin.apple_sdk.frameworks; ''
         echo "-Wno-unused-command-line-argument" >> $out/nix-support/cc-cflags
+        echo "-Wno-elaborated-enum-base" >> $out/nix-support/cc-cflags
         echo "-isystem ${pkgs.llvmPackages.libcxx.dev}/include/c++/v1" >> $out/nix-support/cc-cflags
         echo "-isystem ${pkgs.llvmPackages.clang-unwrapped.lib}/lib/clang/${cc.version}/include" >> $out/nix-support/cc-cflags
         echo "-F${CoreFoundation}/Library/Frameworks" >> $out/nix-support/cc-cflags


### PR DESCRIPTION
To work around https://github.com/llvm/llvm-project/issues/48757.
Without this change builds on MacOS can fail with errors along the lines of
```
/.../process-wrapper '--timeout=0' '--kill_delay=15' external/nixpkgs_config_cc/cc_wrapper.sh -U_FORTIFY_SOURCE -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -fcolor-diagnostics -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections -fdata-sections -x c++ '-std=c++0x' -MD -MF bazel-out/darwin_arm64-opt-exec-C7777A24/bin/external/com_google_absl/absl/time/internal/cctz/_objs/time_zone/time_zone_lookup.d '-frandom-seed=bazel-out/darwin_arm64-opt-exec-C7777A24/bin/external/com_google_absl/absl/time/internal/cctz/_objs/time_zone/time_zone_lookup.o' '-DBAZEL_CURRENT_REPOSITORY="com_google_absl"' -iquote external/com_google_absl -iquote bazel-out/darwin_arm64-opt-exec-C7777A24/bin/external/com_google_absl -g0 -g0 '-std=c++17' -no-canonical-prefixes -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' -c external/com_google_absl/absl/time/internal/cctz/src/time_zone_lookup.cc -o bazel-out/darwin_arm64-opt-exec-C7777A24/bin/external/com_google_absl/absl/time/internal/cctz/_objs/time_zone/time_zone_lookup.o)
In file included from external/com_google_absl/absl/time/internal/cctz/src/time_zone_lookup.cc:26:
In file included from /nix/store/0dh2hqgrnccqlv7hihxh7s9gsz0sy8yz-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/CoreFoundation.framework/Headers/CFTimeZone.h:13:
/nix/store/0dh2hqgrnccqlv7hihxh7s9gsz0sy8yz-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/CoreFoundation.framework/Headers/CFBase.h:474:9: error: non-defining declaration of enumeration with a fixed underlying type is only permitted as a standalone declaration; missing list of enumerators? [-Welaborated-enum-base]
typedef CF_ENUM(CFIndex, CFComparisonResult) {
```
Reported on [Bazel Community Slack](https://bazelbuild.slack.com/archives/CFB3AE72P/p1683625912681759?thread_ts=1683619350.169869&cid=CFB3AE72P). 
