### PR TITLE
rules_go 0.39.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,10 +52,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "685052b498b6ddfe562ca7a97736741d87916fe536623afb7da2824c0211c369",
+    sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
     ],
 )
 

--- a/examples/toolchains/go/WORKSPACE
+++ b/examples/toolchains/go/WORKSPACE
@@ -8,10 +8,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "685052b498b6ddfe562ca7a97736741d87916fe536623afb7da2824c0211c369",
+    sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
     ],
 )
 

--- a/testing/go-bzlmod/MODULE.bazel
+++ b/testing/go-bzlmod/MODULE.bazel
@@ -24,7 +24,7 @@ local_path_override(
     path = "../../toolchains/java",
 )
 
-bazel_dep(name = "rules_go", version = "0.33.0")
+bazel_dep(name = "rules_go", version = "0.39.0")
 bazel_dep(name = "rules_cc", version = "0.0.4")
 
 # TODO[AH] Remove these transitive dependencies once nixpkgs_java_configure has

--- a/testing/go-workspace/WORKSPACE
+++ b/testing/go-workspace/WORKSPACE
@@ -24,10 +24,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "685052b498b6ddfe562ca7a97736741d87916fe536623afb7da2824c0211c369",
+    sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
     ],
 )
 

--- a/toolchains/go/MODULE.bazel
+++ b/toolchains/go/MODULE.bazel
@@ -4,5 +4,6 @@ module(
 )
 
 bazel_dep(name = "rules_nixpkgs_core", version = "0.9.0")
-bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.33.0")
+bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.39.1")
 bazel_dep(name = "bazel_skylib", version = "1.0.3")
+bazel_dep(name = "platforms", version = "0.0.4")

--- a/toolchains/go/WORKSPACE
+++ b/toolchains/go/WORKSPACE
@@ -31,10 +31,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "685052b498b6ddfe562ca7a97736741d87916fe536623afb7da2824c0211c369",
+    sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
     ],
 )
 


### PR DESCRIPTION
This PR updates rules_go to version 0.39.1 and fixes a bzlmod visibility issue caused by the update.

### The issue 
The repository name used internally by rules_go changed in recent versions (from [rules_go](https://github.com/bazelbuild/bazel-central-registry/pull/95/files#diff-2a34841435a86eca4ebbed707b43e505ad768ad5fa76241ffb00098a1cdddd26) to [io_bazel_rules_go](https://github.com/bazelbuild/bazel-central-registry/pull/580/files#diff-0d3abeaeeb83e3563e2118c7e1c0c43b01c9583e9478592d1c5adc23c20a62c7)). As a result, constraints from the `PLATFORMS` variable are now strings referencing the `io_bazel_rules_go` repository.

In the `testing/go-bzlmod` tests, rules_go is visible as `rules_go` so running the tests failed with the following error:

```
No repository visible as '@io_bazel_rules_go' from repository @_main~non_module_deps~nixpkgs_go_sdk_toolchains'
```

### Proposed solution

Instead of generating a bazel file which will `load` the `PLATFORMS` variable, we read this variable directly from the `rules_nixpkgs_go` module (which we know refers to rules_go as `io_bazel_rules_go`) and write a canonicalized version to the bazel file by using the `str(Label(label))` pattern on the labels.
(In non bzlmod, this operation has no effect).