### PR TITLE
go 1.20 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - nixpkgs_nodejs_configure_platforms for platform transparent npm_install
   See [#309]
+  
+### Breaking changes
+- rules_nixpkgs_go: Custom derivations passed to `nixpkgs_go_configure` (via `nix-file`, `nix-file-content` or `attribute_path`) must now contain a `version` attribute.
 
 ## [0.9.0] - 2022-07-19
 

--- a/toolchains/go/README.md
+++ b/toolchains/go/README.md
@@ -171,7 +171,7 @@ default is <code>None</code>
 
 <p>
 
-An expression for a Nix environment derivation. The environment should expose the whole go SDK (`bin`, `src`, ...) at the root of package. It also must contain a `ROOT` file in the root of pacakge. Takes precedence over attribute_path.
+An expression for a Nix environment derivation. The environment should expose the whole go SDK (`bin`, `src`, ...) at the root of package. It also must contain a `ROOT` file in the root of package. Takes precedence over attribute_path.
 
 </p>
 </td>
@@ -181,7 +181,7 @@ An expression for a Nix environment derivation. The environment should expose th
 <td>
 
 optional.
-default is <code>None</code>
+default is <code>[]</code>
 
 <p>
 

--- a/toolchains/go/go.nix
+++ b/toolchains/go/go.nix
@@ -1,0 +1,38 @@
+# Exactly one of goAttrPath or goExpr must be set.
+# If a custom `goExpr` derivation is provided by the user, we add the `go_version.bzl` file to it.
+# Otherwise we create a toolchain based on the `goAttrPath` attribute path from <nixpkgs>
+
+let
+  pkgs = import <nixpkgs> {
+    config = { };
+    overlays = [ ];
+  };
+in args@{ goAttrPath ? null, goExpr ? null }:
+let
+  getVersion = s:
+    s.version or (throw
+      "nix_pkgs_go_configure: the provided go derivation should contain a `version` attribute.");
+
+  bazelGoToolchain = args.goExpr or (let
+    goAttr =
+      pkgs.lib.attrByPath (pkgs.lib.splitString "." goAttrPath) null pkgs;
+  in pkgs.buildEnv {
+    name = "bazel-go-toolchain";
+    paths = [ goAttr ];
+    postBuild = ''
+      touch $out/ROOT
+      ln -s $out/share/go/{api,doc,lib,misc,pkg,src} $out/
+    '';
+  } // {
+    version = getVersion goAttr;
+  });
+
+  goVersionFile = pkgs.runCommand "bazel-go-toolchain-go-version" { } ''
+    mkdir $out
+    echo 'go_version = "${getVersion bazelGoToolchain}"' >> $out/go_version.bzl
+  '';
+
+in pkgs.symlinkJoin {
+  name = "bazel-go-toolchain";
+  paths = [ bazelGoToolchain goVersionFile ];
+}


### PR DESCRIPTION
This PR adds support for go 1.20 to `nixpkgs_go_configure`.

Similarly to what was done in rules_go [here](https://github.com/bazelbuild/rules_go/pull/3385/files#diff-6b36cd5e735033755d6df88acbc31780b4792fb54cec66a592966aba0f275ea1):
- It allows the glob that selects the standard library folder to be empty (because this folder does not exist anymore in version 1.20).
- It passes the version of `go` to the `go_sdk` rule.

In order to recover the version from the nix expression defining the toolchain, we use a `go.nix` wrapper file (similarly to what is done for the cc toolchain) which will add a `go_version.bzl` file to the toolchain.

A breaking change is that derivations passed to `nixpkgs_go_configure` via `nix-file`, `nix-file-content` or `attribute_path` must now contain a `version` attribute.
However I would expect most existing occurrences to use the `attribute_path` of a derivation already containing a `version` attribute (this is the case for the default `go` value).
