### PR TITLE
Improve nix error reporting in bazel logs

### DIFF
--- a/core/util.bzl
+++ b/core/util.bzl
@@ -90,16 +90,15 @@ def execute_or_fail(repository_ctx, arguments, failure_message = "", *args, **kw
     if result.return_code:
         outputs = dict(
             failure_message = failure_message,
-            arguments = arguments,
+            command = " ".join([repr(str(a)) for a in arguments]),
             return_code = result.return_code,
-            stderr = result.stderr,
+            stderr = '      > '.join(('\n'+result.stderr).splitlines(True)),
         )
         fail("""
-{failure_message}
-Command: {arguments}
-Return code: {return_code}
-Error output:
-{stderr}
+  {failure_message}
+    Command: {command}
+    Return code: {return_code}
+    Error output: {stderr}
 """.format(**outputs))
     return result
 


### PR DESCRIPTION

This changes the old ans somewhat monolithic error output format to an indented and hopefully easier to read output.
The indentation in particular is intended make the log easier to parse, especially when color is disabled as in CI.

New:

```
ERROR: An error occurred during the fetch of repository 'foo':
   Traceback (most recent call last):
        File ".../external/rules_nixpkgs_core/nixpkgs.bzl", line 312, column 34, in _nixpkgs_package_impl
                exec_result = execute_or_fail(
        File ".../external/rules_nixpkgs_core/util.bzl", line 76, column 13, in execute_or_fail
                fail("""
Error in fail:
  Cannot build Nix attribute ''.
    Command: ".../nix-build" "-I" "nixpkgs=.../host_nixpkgs/host_nixpkgs" "-E" "some expr" "-A" "" "--out-link" "bazel-support/nix-out-link"
    Return code: 1
    Error output:
      > this derivation will be built:
      >   /nix/store/<hash>-foo-1.0.drv
      > building '/nix/store/<hash>-foo-1.0.drv'...
      > unpacking sources
      > unpacking source archive /nix/store/<hash>-source
      > source root is source
      > patching sources
      > configuring
      > no configure script, doing nothing
      > building
      > error: builder for '/nix/store/<hash>-foo-1.0.drv' failed with exit code 1;
      >        last 8 log lines:
      >        > unpacking sources
      >        > unpacking source archive /nix/store/<hash>-source
      >        > source root is source
      >        > patching sources
      >        > configuring
      >        > no configure script, doing nothing
      >        > building
      >        For full logs, run 'nix log /nix/store/<hash>-foo-1.0.drv'.
```

Old:

```
ERROR: An error occurred during the fetch of repository 'foo':
   Traceback (most recent call last):
	File ".../external/rules_nixpkgs_core/nixpkgs.bzl", line 312, column 34, in _nixpkgs_package_impl
		exec_result = execute_or_fail(
	File ".../external/rules_nixpkgs_core/util.bzl", line 76, column 13, in execute_or_fail
		fail("""
Error in fail: 
Cannot build Nix attribute ''.
Command: [.../nix-build, "-I", "nixpkgs=.../host_nixpkgs/host_nixpkgs", "-E", "some expr", "-A", "", "--out-link", "bazel-support/nix-out-link"]
Return code: 1
Error output:
this derivation will be built:
  /nix/store/<hash>-foo-1.0.drv
building '/nix/store/<hash>-foo-1.0.drv'...
unpacking sources
unpacking source archive /nix/store/<hash>-source
source root is source
patching sources
configuring
no configure script, doing nothing
building
error: builder for '/nix/store/<hash>-foo-1.0.drv' failed with exit code 1;
       last 8 log lines:
       > unpacking sources
       > unpacking source archive /nix/store/<hash>-source
       > source root is source
       > patching sources
       > configuring
       > no configure script, doing nothing
       > building
       For full logs, run 'nix log /nix/store/<hash>-foo-1.0.drv'.
```
