### PR TITLE
cc: Add cross_cpu arg to nixpkgs_cc_toolchain_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ nixpkgs_package(
 <pre>
 nixpkgs_cc_configure(<a href="#nixpkgs_cc_configure-name">name</a>, <a href="#nixpkgs_cc_configure-attribute_path">attribute_path</a>, <a href="#nixpkgs_cc_configure-nix_file">nix_file</a>, <a href="#nixpkgs_cc_configure-nix_file_content">nix_file_content</a>, <a href="#nixpkgs_cc_configure-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_cc_configure-repositories">repositories</a>,
                      <a href="#nixpkgs_cc_configure-repository">repository</a>, <a href="#nixpkgs_cc_configure-nixopts">nixopts</a>, <a href="#nixpkgs_cc_configure-quiet">quiet</a>, <a href="#nixpkgs_cc_configure-fail_not_supported">fail_not_supported</a>, <a href="#nixpkgs_cc_configure-exec_constraints">exec_constraints</a>,
-                     <a href="#nixpkgs_cc_configure-target_constraints">target_constraints</a>, <a href="#nixpkgs_cc_configure-register">register</a>, <a href="#nixpkgs_cc_configure-cc_lang">cc_lang</a>)
+                     <a href="#nixpkgs_cc_configure-target_constraints">target_constraints</a>, <a href="#nixpkgs_cc_configure-register">register</a>, <a href="#nixpkgs_cc_configure-cc_lang">cc_lang</a>, <a href="#nixpkgs_cc_configure-cross_cpu">cross_cpu</a>)
 </pre>
 
 Use a CC toolchain from Nixpkgs. No-op if not a nix-based platform.
@@ -379,6 +379,20 @@ default is <code>"c++"</code>
 <p>
 
 string, `"c++"` by default. Used to populate `CXX_FLAG` so the compiler is called in C++ mode. Can be set to `"none"` together with appropriate `copts` in the `cc_library` call: see above.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure-cross_cpu">
+<td><code>cross_cpu</code></td>
+<td>
+
+optional.
+default is <code>""</code>
+
+<p>
+
+string, `""` by default. Used if you want to add a cross compilation C/C++ toolchain. Set this to the CPU architecture for the target CPU. For example x86_64, would be k8.
 
 </p>
 </td>

--- a/toolchains/cc/README.md
+++ b/toolchains/cc/README.md
@@ -31,7 +31,7 @@ using `nixpkgs_cc_configure(..., cc_lang = "cuda")` or similar.
 <pre>
 nixpkgs_cc_configure(<a href="#nixpkgs_cc_configure-name">name</a>, <a href="#nixpkgs_cc_configure-attribute_path">attribute_path</a>, <a href="#nixpkgs_cc_configure-nix_file">nix_file</a>, <a href="#nixpkgs_cc_configure-nix_file_content">nix_file_content</a>, <a href="#nixpkgs_cc_configure-nix_file_deps">nix_file_deps</a>, <a href="#nixpkgs_cc_configure-repositories">repositories</a>,
                      <a href="#nixpkgs_cc_configure-repository">repository</a>, <a href="#nixpkgs_cc_configure-nixopts">nixopts</a>, <a href="#nixpkgs_cc_configure-quiet">quiet</a>, <a href="#nixpkgs_cc_configure-fail_not_supported">fail_not_supported</a>, <a href="#nixpkgs_cc_configure-exec_constraints">exec_constraints</a>,
-                     <a href="#nixpkgs_cc_configure-target_constraints">target_constraints</a>, <a href="#nixpkgs_cc_configure-register">register</a>, <a href="#nixpkgs_cc_configure-cc_lang">cc_lang</a>)
+                     <a href="#nixpkgs_cc_configure-target_constraints">target_constraints</a>, <a href="#nixpkgs_cc_configure-register">register</a>, <a href="#nixpkgs_cc_configure-cc_lang">cc_lang</a>, <a href="#nixpkgs_cc_configure-cross_cpu">cross_cpu</a>)
 </pre>
 
 Use a CC toolchain from Nixpkgs. No-op if not a nix-based platform.
@@ -286,6 +286,20 @@ default is <code>"c++"</code>
 <p>
 
 string, `"c++"` by default. Used to populate `CXX_FLAG` so the compiler is called in C++ mode. Can be set to `"none"` together with appropriate `copts` in the `cc_library` call: see above.
+
+</p>
+</td>
+</tr>
+<tr id="nixpkgs_cc_configure-cross_cpu">
+<td><code>cross_cpu</code></td>
+<td>
+
+optional.
+default is <code>""</code>
+
+<p>
+
+string, `""` by default. Used if you want to add a cross compilation C/C++ toolchain. Set this to the CPU architecture for the target CPU. For example x86_64, would be k8.
 
 </p>
 </td>


### PR DESCRIPTION
Currently, we hardcode the CPU architecture of the toolchain to the host toolchain. However, this breaks cross compilation as we will probably want to set the CPU of the toolchain to the target architecture. The `cross_cpu` flag can be used to specify the target architecture. If the `cross_cpu` flag is not set, we will auto detect the host CPU architecture and use that for the toolchain.

This is part of an effort to address #347