### PR TITLE
Add support for nix store remote copying

### DIFF
--- a/.github/nix-server/Dockerfile
+++ b/.github/nix-server/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:23.04
+
+RUN apt-get update -qq && \
+    apt-get install openssh-server curl xz-utils sudo locales ca-certificates -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -m 0755 /nix && \
+    groupadd -r nixbld && \
+    chown root /nix && \
+    for n in $(seq 1 10); do useradd -c "Nix build user $n" -d /var/empty -g nixbld -G nixbld -M -N -r -s "$(command -v nologin)" "nixbld$n"; done
+
+RUN curl -L https://nixos.org/nix/install | bash
+
+COPY .github/nix-server/keys .
+
+RUN cat ci.pub > $HOME/.ssh/authorized_keys
+
+RUN echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config
+
+CMD ["/usr/sbin/sshd", "-D"]

--- a/.github/nix-server/Dockerfile
+++ b/.github/nix-server/Dockerfile
@@ -16,6 +16,9 @@ COPY .github/nix-server/keys .
 
 RUN cat ci.pub > $HOME/.ssh/authorized_keys
 
-RUN echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config
+RUN echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config && \
+    echo ". /root/.nix-profile/etc/profile.d/nix.sh" >> $HOME/.bashrc && \
+    ln -sf /root/.nix-profile/bin/nix-store /usr/bin/ && \
+    ln -sf /root/.nix-profile/bin/nix-daemon /usr/bin/
 
 CMD ["/usr/sbin/sshd", "-D"]

--- a/.github/nix-server/config
+++ b/.github/nix-server/config
@@ -1,0 +1,5 @@
+Host nix-server
+  Hostname localhost
+  Port 2222
+  User root
+  IdentityFile .github/nix-server/keys/ci

--- a/.github/nix-server/config
+++ b/.github/nix-server/config
@@ -3,3 +3,7 @@ Host nix-server
   Port 2222
   User root
   IdentityFile .github/nix-server/keys/ci
+
+Host *
+    StrictHostKeyChecking no
+    UserKnownHostsFile=/dev/null

--- a/.github/nix-server/config
+++ b/.github/nix-server/config
@@ -2,7 +2,7 @@ Host nix-server
   Hostname localhost
   Port 2222
   User root
-  IdentityFile .github/nix-server/keys/ci
+  IdentityFile /home/runner/.ssh/ci
 
 Host *
     StrictHostKeyChecking no

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -69,8 +69,10 @@ jobs:
       - name: Build & test
         env:
           BZLMOD_ENABLED: ${{ matrix.bzlmodEnabled }}
+          NIX_REMOTE_ENABLED: matrix.withNixRemote && matrix.os == 'ubuntu-latest'
         run: |
-          if [ ${{ matrix.withNixRemote }} = "true" ]; then
+          if [ "$NIX_REMOTE_ENABLED" = "true" ]; then
+            echo "Setting BAZEL_NIX_REMOTE env variable"
             export BAZEL_NIX_REMOTE=nix-server
           fi
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -63,9 +63,6 @@ jobs:
           docker build -t nix-server -f .github/nix-server/Dockerfile .
           docker run -d -p 2222:22 nix-server
 
-          sudo apt-get update -qq
-          sudo apt-get install openssh-client -y
-
           cp .github/nix-server/config $HOME/.ssh/config
           cat $HOME/.ssh/config
           sudo chmod -R 600 $HOME/.ssh/
@@ -79,8 +76,6 @@ jobs:
         run: |
           if [ ${{ matrix.withNixRemote }} = "true" ]; then
             export BAZEL_NIX_REMOTE=nix-server
-
-            nix store ping --store ssh://nix-server
           fi
 
           nix-shell --pure \

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -64,9 +64,15 @@ jobs:
           docker run -d -p 2222:22 nix-server
 
           sudo apt-get update -qq
-          sudo apt-get install openssh-server -y
+          sudo apt-get install openssh-client -y
 
           cp .github/nix-server/config $HOME/.ssh/config
+          cat $HOME/.ssh/config
+          sudo chmod -R 600 $HOME/.ssh/
+          echo $HOME
+          pwd
+          id
+          ssh -V
       - name: Build & test
         env:
           BZLMOD_ENABLED: ${{ matrix.bzlmodEnabled }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -27,6 +27,9 @@ jobs:
         bzlmodEnabled:
           - true
           - false
+        withNixRemote:
+          - true
+          - false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.6.0
@@ -49,13 +52,31 @@ jobs:
           # no-op flag to avoid "ERROR: Config value 'ci' is not defined in any .rc file"
           common:ci --announce_rc=false
           EOF
+      - name: Start remote Nix server
+        if: ${{ matrix.withNixRemote }} == "true"
+        run: |
+          # Generate temporary SSH keys.
+          mkdir -p $HOME/.ssh
+          mkdir -p .github/nix-server/keys
+          ssh-keygen -t ed25519 -f .github/nix-server/keys/ci -C ci-nix-server -q -N ""
+
+          docker build -t nix-server -f .github/nix-server/Dockerfile .
+          docker run -p 2222:22 nix-server
+
+          cp .github/nix-server/config $HOME/.ssh/config
       - name: Build & test
         env:
           BZLMOD_ENABLED: ${{ matrix.bzlmodEnabled }}
+          NIX_REMOTE_ENABLED: ${{ matrix.withNixRemote }}
         run: |
+          if [ "$NIX_REMOTE_ENABLED" == "true" ]; then
+            export BAZEL_NIX_REMOTE=nix-server
+          fi
+
           nix-shell --pure \
             --keep GITHUB_REPOSITORY \
             --keep BZLMOD_ENABLED \
+            --keep BAZEL_NIX_REMOTE \
             --run 'bash .github/build-and-test'
   test-examples:
     name: Build & Test - Examples

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -68,7 +68,7 @@ jobs:
         env:
           BZLMOD_ENABLED: ${{ matrix.bzlmodEnabled }}
         run: |
-          if [ ${{ matrix.withNixRemote }} = true ]; then
+          if [ ${{ matrix.withNixRemote }} = "true" ]; then
             export BAZEL_NIX_REMOTE=nix-server
           fi
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
   test-nixpkgs:
-    name: Build & Test - Nixpkgs - ${{ matrix.bzlmodEnabled && 'bzlmod' || 'workspace' }} - ${{ matrix.os }}
+    name: Build & Test - Nixpkgs - ${{ matrix.bzlmodEnabled && 'bzlmod' || 'workspace' }} ${{ matrix.withNixRemote && '- NixRemote' || '' }} - ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -79,6 +79,8 @@ jobs:
         run: |
           if [ ${{ matrix.withNixRemote }} = "true" ]; then
             export BAZEL_NIX_REMOTE=nix-server
+
+            nix store ping --store ssh://nix-server
           fi
 
           nix-shell --pure \

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -53,7 +53,7 @@ jobs:
           common:ci --announce_rc=false
           EOF
       - name: Start remote Nix server
-        if: ${{ matrix.withNixRemote }} == "true" && ${{ matrix.os }} == "ubuntu-latest"
+        if: ${{ matrix.withNixRemote == "true" }} && ${{ matrix.os == "ubuntu-latest" }}
         run: |
           # Generate temporary SSH keys.
           mkdir -p $HOME/.ssh
@@ -67,9 +67,8 @@ jobs:
       - name: Build & test
         env:
           BZLMOD_ENABLED: ${{ matrix.bzlmodEnabled }}
-          NIX_REMOTE_ENABLED: ${{ matrix.withNixRemote }}
         run: |
-          if [ "$NIX_REMOTE_ENABLED" == "true" ]; then
+          if [ ${{ matrix.withNixRemote }} = true ]; then
             export BAZEL_NIX_REMOTE=nix-server
           fi
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -53,7 +53,7 @@ jobs:
           common:ci --announce_rc=false
           EOF
       - name: Start remote Nix server
-        if: ${{ matrix.withNixRemote == "true" }} && ${{ matrix.os == "ubuntu-latest" }}
+        if: matrix.withNixRemote && matrix.os == 'ubuntu-latest'
         run: |
           # Generate temporary SSH keys.
           mkdir -p $HOME/.ssh

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -53,7 +53,7 @@ jobs:
           common:ci --announce_rc=false
           EOF
       - name: Start remote Nix server
-        if: ${{ matrix.withNixRemote }} == "true"
+        if: ${{ matrix.withNixRemote }} == "true" && ${{ matrix.os }} == "ubuntu-latest"
         run: |
           # Generate temporary SSH keys.
           mkdir -p $HOME/.ssh
@@ -61,7 +61,7 @@ jobs:
           ssh-keygen -t ed25519 -f .github/nix-server/keys/ci -C ci-nix-server -q -N ""
 
           docker build -t nix-server -f .github/nix-server/Dockerfile .
-          docker run -p 2222:22 nix-server
+          docker run -d -p 2222:22 nix-server
 
           cp .github/nix-server/config $HOME/.ssh/config
       - name: Build & test

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -64,12 +64,7 @@ jobs:
           docker run -d -p 2222:22 nix-server
 
           cp .github/nix-server/config $HOME/.ssh/config
-          cat $HOME/.ssh/config
           sudo chmod -R 600 $HOME/.ssh/
-          echo $HOME
-          pwd
-          id
-          ssh -V
       - name: Build & test
         env:
           BZLMOD_ENABLED: ${{ matrix.bzlmodEnabled }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
   test-nixpkgs:
-    name: Build & Test - Nixpkgs - ${{ matrix.bzlmodEnabled && 'bzlmod' || 'workspace' }} ${{ matrix.withNixRemote && '- NixRemote' || '' }} - ${{ matrix.os }}
+    name: Build & Test - Nixpkgs - ${{ matrix.bzlmodEnabled && 'bzlmod' || 'workspace' }} ${{ matrix.withNixRemote && '- NixRemote ' || '' }}- ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -63,6 +63,8 @@ jobs:
           docker build -t nix-server -f .github/nix-server/Dockerfile .
           docker run -d -p 2222:22 nix-server
 
+          cp .github/nix-server/keys/* $HOME/.ssh/
+
           sudo cp .github/nix-server/config /etc/ssh/ssh_config
       - name: Build & test
         env:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -63,8 +63,7 @@ jobs:
           docker build -t nix-server -f .github/nix-server/Dockerfile .
           docker run -d -p 2222:22 nix-server
 
-          cp .github/nix-server/config $HOME/.ssh/config
-          sudo chmod -R 600 $HOME/.ssh/
+          sudo cp .github/nix-server/config /etc/ssh/ssh_config
       - name: Build & test
         env:
           BZLMOD_ENABLED: ${{ matrix.bzlmodEnabled }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -63,6 +63,9 @@ jobs:
           docker build -t nix-server -f .github/nix-server/Dockerfile .
           docker run -d -p 2222:22 nix-server
 
+          sudo apt-get update -qq
+          sudo apt-get install openssh-server -y
+
           cp .github/nix-server/config $HOME/.ssh/config
       - name: Build & test
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /**/bazel-*
 
 /**/node_modules
+
+.github/nix-server/keys

--- a/core/nixpkgs.bzl
+++ b/core/nixpkgs.bzl
@@ -429,7 +429,7 @@ def _nixpkgs_build_and_symlink(repository_ctx, nix_build_cmd, expr_args, build_f
         repository_ctx.report_progress("Creating remote store root")
         exec_result = execute_or_fail(
             repository_ctx,
-            [ssh_path] + [nix_host, "nix-store --add-root /nix/var/nix/gcroots/per-user/nix/rules_nixpkgs_{root} -r {path}".format(root = output_path.split('/')[-1], path = output_path) ],
+            [ssh_path] + [nix_host, "nix-store --add-root ~/rules_nixpkgs_gcroots/{root} -r {path}".format(root = output_path.split('/')[-1], path = output_path) ],
             failure_message = "Cannot create remote store root for Nix attribute '{}'.".format(
                 repository_ctx.attr.name,
             ),

--- a/core/nixpkgs.bzl
+++ b/core/nixpkgs.bzl
@@ -431,7 +431,6 @@ def _nixpkgs_build_and_symlink(repository_ctx, nix_path, expr_args, build_file_c
             timeout = 10000,
         )
 
-        nix_path = repository_ctx.which("nix")
         repository_ctx.report_progress("Downloading Nix derivation")
         exec_result = repository_ctx.execute(
             [nix_path, "copy", "--from", nix_store, output_path],

--- a/core/nixpkgs.bzl
+++ b/core/nixpkgs.bzl
@@ -396,7 +396,7 @@ def _nixpkgs_build_file_content(repository_ctx):
     else:
         return None
 
-def _nixpkgs_build_and_symlink(repository_ctx, nix_build_path, expr_args, build_file_content):
+def _nixpkgs_build_and_symlink(repository_ctx, nix_path, expr_args, build_file_content):
     # Large enough integer that Bazel can still parse. We don't have
     # access to MAX_INT and 0 is not a valid timeout so this is as good
     # as we can do. The value shouldn't be too large to avoid errors on
@@ -410,7 +410,7 @@ def _nixpkgs_build_and_symlink(repository_ctx, nix_build_path, expr_args, build_
         repository_ctx.report_progress("Remote-building Nix derivation")
         exec_result = execute_or_fail(
              repository_ctx,
-             [nix_build_path, "--store", nix_store, "--eval-store", "auto"] + expr_args,
+             [nix_path, "build", "--store", nix_store, "--eval-store", "auto"] + expr_args,
              failure_message = "Cannot build Nix attribute '{}'.".format(
                  repository_ctx.attr.attribute_path,
              ),
@@ -441,7 +441,7 @@ def _nixpkgs_build_and_symlink(repository_ctx, nix_build_path, expr_args, build_
 
     exec_result = execute_or_fail(
         repository_ctx,
-        [nix_build_path] + expr_args,
+        [nix_path, "build"] + expr_args,
         failure_message = "Cannot build Nix derivation for package '@{}'.".format(repository_ctx.name),
         quiet = repository_ctx.attr.quiet,
         timeout = timeout,
@@ -575,13 +575,13 @@ def _nixpkgs_package_impl(repository_ctx):
         for opt in repository_ctx.attr.nixopts
     ])
 
-    nix_build_path = executable_path(
+    nix_path = executable_path(
         repository_ctx,
-        "nix-build",
+        "nix",
         extra_msg = "See: https://nixos.org/nix/",
     )
 
-    _nixpkgs_build_and_symlink(repository_ctx, nix_build_path, expr_args, build_file_content)
+    _nixpkgs_build_and_symlink(repository_ctx, nix_path, expr_args, build_file_content)
 
 _nixpkgs_package = repository_rule(
     implementation = _nixpkgs_package_impl,
@@ -778,9 +778,8 @@ def _nixpkgs_flake_package_impl(repository_ctx):
         "nix",
         extra_msg = "See: https://nixos.org/nix/",
     )
-    nix_build = [nix_path, "build"] + expr_args
 
-    _nixpkgs_build_and_symlink(repository_ctx, nix_build, build_file_content)
+    _nixpkgs_build_and_symlink(repository_ctx, nix_path, expr_args, build_file_content)
 
 _nixpkgs_flake_package = repository_rule(
     implementation = _nixpkgs_flake_package_impl,

--- a/core/nixpkgs.bzl
+++ b/core/nixpkgs.bzl
@@ -418,7 +418,7 @@ def _nixpkgs_build_and_symlink(repository_ctx, nix_build_cmd, expr_args, build_f
              repository_ctx,
              nix_build_cmd + ["--store", nix_store, "--eval-store", "auto"] + expr_args,
              failure_message = "Cannot build Nix attribute '{}'.".format(
-                 repository_ctx.attr.attribute_path,
+                 repository_ctx.attr.name,
              ),
              quiet = repository_ctx.attr.quiet,
              timeout = timeout,
@@ -430,8 +430,8 @@ def _nixpkgs_build_and_symlink(repository_ctx, nix_build_cmd, expr_args, build_f
         exec_result = execute_or_fail(
             repository_ctx,
             [ssh_path] + [nix_host, "nix-store --add-root /nix/var/nix/gcroots/per-user/nix/rules_nixpkgs_{root} -r {path}".format(root = output_path.split('/')[-1], path = output_path) ],
-            failure_message = "Cannot build Nix attribute '{}'.".format(
-                repository_ctx.attr.attribute_path,
+            failure_message = "Cannot create remote store root for Nix attribute '{}'.".format(
+                repository_ctx.attr.name,
             ),
             quiet = repository_ctx.attr.quiet,
             timeout = 10000,

--- a/core/nixpkgs.bzl
+++ b/core/nixpkgs.bzl
@@ -396,7 +396,7 @@ def _nixpkgs_build_file_content(repository_ctx):
     else:
         return None
 
-def _nixpkgs_build_and_symlink(repository_ctx, nix_path, expr_args, build_file_content):
+def _nixpkgs_build_and_symlink(repository_ctx, nix_build, build_file_content):
     # Large enough integer that Bazel can still parse. We don't have
     # access to MAX_INT and 0 is not a valid timeout so this is as good
     # as we can do. The value shouldn't be too large to avoid errors on
@@ -404,13 +404,19 @@ def _nixpkgs_build_and_symlink(repository_ctx, nix_path, expr_args, build_file_c
     timeout = 8640000
     repository_ctx.report_progress("Building Nix derivation")
 
+    nix_path = executable_path(
+        repository_ctx,
+        "nix",
+        extra_msg = "See: https://nixos.org/nix/",
+    )
+
     nix_host = repository_ctx.os.environ.get('BAZEL_NIX_REMOTE', '')
     if nix_host:
         nix_store = "ssh-ng://{host}?max-connections=1".format(host = nix_host)
         repository_ctx.report_progress("Remote-building Nix derivation")
         exec_result = execute_or_fail(
              repository_ctx,
-             [nix_path, "build", "--store", nix_store, "--eval-store", "auto"] + expr_args,
+             [nix_path, "build", "--store", nix_store, "--eval-store", "auto"],
              failure_message = "Cannot build Nix attribute '{}'.".format(
                  repository_ctx.attr.attribute_path,
              ),
@@ -440,7 +446,7 @@ def _nixpkgs_build_and_symlink(repository_ctx, nix_path, expr_args, build_file_c
 
     exec_result = execute_or_fail(
         repository_ctx,
-        [nix_path, "build"] + expr_args,
+        nix_build,
         failure_message = "Cannot build Nix derivation for package '@{}'.".format(repository_ctx.name),
         quiet = repository_ctx.attr.quiet,
         timeout = timeout,
@@ -574,13 +580,15 @@ def _nixpkgs_package_impl(repository_ctx):
         for opt in repository_ctx.attr.nixopts
     ])
 
-    nix_path = executable_path(
+    nix_build_path = executable_path(
         repository_ctx,
-        "nix",
+        "nix-build",
         extra_msg = "See: https://nixos.org/nix/",
     )
 
-    _nixpkgs_build_and_symlink(repository_ctx, nix_path, expr_args, build_file_content)
+    nix_build = [nix_build_path] + expr_args
+
+    _nixpkgs_build_and_symlink(repository_ctx, nix_build, build_file_content)
 
 _nixpkgs_package = repository_rule(
     implementation = _nixpkgs_package_impl,
@@ -777,8 +785,9 @@ def _nixpkgs_flake_package_impl(repository_ctx):
         "nix",
         extra_msg = "See: https://nixos.org/nix/",
     )
+    nix_build = [nix_path, "build"] + expr_args
 
-    _nixpkgs_build_and_symlink(repository_ctx, nix_path, expr_args, build_file_content)
+    _nixpkgs_build_and_symlink(repository_ctx, nix_build, build_file_content)
 
 _nixpkgs_flake_package = repository_rule(
     implementation = _nixpkgs_flake_package_impl,

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
       {
         devShells.default = with pkgs; mkShell {
           name = "rules_nixpkgs_shell";
-          packages = [ bazel_6 bazel-buildtools cacert gcc nix git ];
+          packages = [ bazel_6 bazel-buildtools cacert gcc nix git openssh ];
         };
       });
 }


### PR DESCRIPTION
This is a requirement in order to make Bazel remote execution work. Without it it's not guaranteed that any necessary nix paths will be available during the build.

Any local derivation will be copied over to a specified remote nix server which will also as a Bazel executor. This way any nix paths required during the build, will be available.

The user will have to provide the `BAZEL_NIX_REMOTE` environment variable. This should be the name of any entry on the SSH_CONFIG file where all the authentication details are provided.

e.g

```bash
$ export BAZEL_NIX_REMOTE=nix-server

$ cat ~/.ssh/config
Host nix-server
  Hostname 1.2.3.4
  IdentityFile ~/.ssh/nix-server
  Port 2222
  User nix-user
```

This was done in order to simplify the processes of authentication and keep the number of configuration options to a minimum.