### PR TITLE
python: Expose the requirements.json file

### DIFF
--- a/toolchains/python/python.bzl
+++ b/toolchains/python/python.bzl
@@ -316,6 +316,7 @@ def nixpkgs_python_repository(
         repository = repository,
         repositories = repositories,
         nix_file_deps = nix_file_deps + [ nix_file ],
+        build_file_content = """exports_files(["requirements.json"])""",
         nixopts = [ "--arg", "nix_file", "$(location {})".format(nix_file) ],
         quiet = quiet,
     )


### PR DESCRIPTION
This file has the nix store paths for a set of python deps. This is useful if you want to extract these files for caching or dependency resolution similar to what python gazelle does.