### PR TITLE
forward http_archive type to submodules

### DIFF
--- a/nixpkgs/repositories.bzl
+++ b/nixpkgs/repositories.bzl
@@ -90,6 +90,7 @@ def rules_nixpkgs_dependencies(rules_nixpkgs_name = "io_tweag_rules_nixpkgs", to
                 url = rules_nixpkgs.get("url"),
                 urls = rules_nixpkgs.get("urls"),
                 sha256 = rules_nixpkgs.get("sha256"),
+                type = rules_nixpkgs.get("type"),
             )
         elif kind == "git_repository":
             maybe(


### PR DESCRIPTION
This may be very specific to our deployment, but in my teams monorepo, we require any `http_archive` dependencies to be mirrored with a standardized file name.

As an example, we would depend on rules_nixpkgs like this:

```starlark
http_archive(
    name = "io_tweag_rules_nixpkgs",
    sha256 = "3ff4a25c8021ce2b0a15b4892acd2246fb1aae1d143ecdbd12bb770ad6e1741d",
    strip_prefix = "rules_nixpkgs-52d34c00171acd04d27626571d7d40748d648d2a",
    urls = [
        "https://cdn.confidential.cloud/constellation/cas/sha256/3ff4a25c8021ce2b0a15b4892acd2246fb1aae1d143ecdbd12bb770ad6e1741d",
        "https://github.com/tweag/rules_nixpkgs/archive/52d34c00171acd04d27626571d7d40748d648d2a.tar.gz",
    ],
    type = "tar.gz",
)
```

This requires us to specify the `type` field in `http_archive` and to also forward this field in other `http_archive` rules that are created from the original rule.