### PR TITLE
Add support for Go 1.21

### DIFF
--- a/toolchains/go/go.nix
+++ b/toolchains/go/go.nix
@@ -21,7 +21,7 @@ let
     paths = [ goAttr ];
     postBuild = ''
       touch $out/ROOT
-      ln -s $out/share/go/{api,doc,lib,misc,pkg,src} $out/
+      ln -s $out/share/go/{api,doc,lib,misc,pkg,src,go.env} $out/
     '';
   } // {
     version = getVersion goAttr;


### PR DESCRIPTION
Go 1.21 added a requirement for a 'go.env' file. Without that file, Go will throw an error like:
```
Error in fail: failed to fetch org_golang_google_grpc_cmd_protoc_gen_go_grpc: fetch_repo: google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0: GOPROXY list is not the empty string, but contains no entries
```

This commit adds it to the SDK exposed by rules_nixpkgs so that it is compatible with rules_go.

See:
- https://github.com/bazelbuild/rules_go/issues/3665
- https://github.com/bazelbuild/rules_go/pull/3666