### PR TITLE
Exclude .bazeliskrc from git archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.bazeliskrc export-ignore


### PR DESCRIPTION
Closes https://github.com/tweag/rules_nixpkgs/issues/373

The issue reported at https://github.com/tweag/rules_nixpkgs/issues/373 is that Zip archives are not allowed to include symlinks that go outside of the extracted folders. This is a problem for rules_nixpkgs, because the core and toolchain modules are meant to be extracted with `strip_prefix` set to `core`, `toolchains/python`, etc.

The specific issue with `.bazelrc` files has been resolved since, by replacing symlinks by textual load references in the files themselves.
However, since then the repository gained a new set of symlinks: `.bazeliskrc` files, introduced in fbeacfd5651566c2ad8e02c5f92de732f4d19f96. These cannot be replaced by textual references, and we cannot switch to a single toplevel `.bazelversion` file as that breaks with a Nix provided Bazel due to https://github.com/NixOS/nixpkgs/issues/80950.

This PR solves the issue by excluding these files from Git generated archives via an `export-ignore` entry in `.gitattributes`.
