### PR TITLE
Add clang resource share directory to search path

### DIFF
--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -143,6 +143,12 @@ pkgs.runCommand "bazel-${cc.orignalName or cc.name}-toolchain"
         | xargs -0 -r realpath -ms
     }
     CXX_BUILTIN_INCLUDE_DIRECTORIES=($({
+      if is_compiler_option_supported -print-resource-dir; then
+        resource_dir="$( $cc -print-resource-dir )"
+        if [ -d "$resource_dir/share" ]; then
+          echo "$resource_dir/share"
+        fi
+      fi
       include_dirs_for c
       include_dirs_for c++
       if is_compiler_option_supported -fno-canonical-system-headers; then


### PR DESCRIPTION
This is needed e.g. when using `-fsanitize=address` which would otherwise fail with:
```
this rule is missing dependency declarations for the following files included by ...
 '/nix/store/9k6s3zmhj2pvkg8a5s8n7d2sbpffv8hv-clang-wrapper-16.0.1/resource-root/share/asan_ignorelist.txt'
```

Fixes #430

See https://github.com/bazelbuild/bazel/commit/f32b0fde39fc34dd1f63fef3513ff6d1e5db46e7 and https://github.com/bazelbuild/bazel/issues/10510 for similar work.