### PR TITLE
go: add experiments=nocoverageredesign for go_sdk in 1.20+

### DIFF
--- a/toolchains/go/go.bzl
+++ b/toolchains/go/go.bzl
@@ -81,8 +81,13 @@ def go_sdk_for_arch(go_version):
         ),
     )
 
+    experiments = []
+    if go_version.split('.')[0] == '1' and int(go_version.split('.')[1]) >= 20:
+        experiments = ["nocoverageredesign"]
+
     go_sdk(
         name = "go_sdk",
+        experiments = experiments,
         goos = "{goos}",
         goarch = "{goarch}",
         root_file = "ROOT",


### PR DESCRIPTION
[rules_go adds experiments=nocoverageredesign](https://github.com/bazelbuild/rules_go/blob/v0.42.0/go/private/sdk.bzl#L486-L491) automatically. rules_nixpkgs doesn't add this, so `bazel coverage` fails with `testing: cannot use -test.coverprofile because test binary was not built with coverage enabled`. 