### PR TITLE
Use non-prebuild Java toolchain configuration

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -20,6 +20,8 @@
         devShells.default = with pkgs; mkShell {
           # do not use Xcode on macOS
           BAZEL_USE_CPP_ONLY_TOOLCHAIN = "1";
+          # for nixpkgs cc wrappers, select C++ explicitly (see https://github.com/NixOS/nixpkgs/issues/150655)
+          BAZEL_CXXOPTS = "-x:c++";
 
           name = "rules_nixpkgs_shell";
           packages = [ bazel_6 bazel-buildtools cacert gcc nix git openssh ];

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -24,6 +24,7 @@
           BAZEL_CXXOPTS = "-x:c++";
 
           name = "rules_nixpkgs_shell";
+          buildInputs = lib.optional pkgs.stdenv.isDarwin darwin.cctools;
           packages = [ bazel_6 bazel-buildtools cacert gcc nix git openssh ];
         };
       });

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -18,6 +18,9 @@
       in
       {
         devShells.default = with pkgs; mkShell {
+          # do not use Xcode on macOS
+          BAZEL_USE_CPP_ONLY_TOOLCHAIN = "1";
+
           name = "rules_nixpkgs_shell";
           packages = [ bazel_6 bazel-buildtools cacert gcc nix git openssh ];
         };

--- a/testing/cc/MODULE.bazel
+++ b/testing/cc/MODULE.bazel
@@ -24,7 +24,7 @@ bazel_dep(name = "rules_cc", version = "0.0.4")
 # TODO[AH] Remove these transitive dependencies once nixpkgs_java_configure has
 #   become a module extension in rules_nixpkgs_java.
 bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "rules_java", version = "4.0.0")
+bazel_dep(name = "rules_java", version = "6.5.2")
 
 java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
 use_repo(java_toolchains, "remote_java_tools")

--- a/testing/go-bzlmod/MODULE.bazel
+++ b/testing/go-bzlmod/MODULE.bazel
@@ -30,7 +30,7 @@ bazel_dep(name = "rules_cc", version = "0.0.4")
 # TODO[AH] Remove these transitive dependencies once nixpkgs_java_configure has
 #   become a module extension in rules_nixpkgs_java.
 bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "rules_java", version = "4.0.0")
+bazel_dep(name = "rules_java", version = "6.5.2")
 
 java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
 use_repo(java_toolchains, "remote_java_tools")

--- a/testing/java/MODULE.bazel
+++ b/testing/java/MODULE.bazel
@@ -17,7 +17,7 @@ bazel_dep(name = "bazel_skylib", version = "1.0.3")
 # TODO[AH] Remove these transitive dependencies once nixpkgs_java_configure has
 #   become a module extension in rules_nixpkgs_java.
 bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "rules_java", version = "4.0.0")
+bazel_dep(name = "rules_java", version = "6.5.2")
 
 java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
 use_repo(java_toolchains, "remote_java_tools")

--- a/testing/nodejs/MODULE.bazel
+++ b/testing/nodejs/MODULE.bazel
@@ -31,7 +31,7 @@ bazel_dep(name = "rules_nodejs", version = "5.5.3")
 # TODO[AH] Remove these transitive dependencies once nixpkgs_java_configure has
 #   become a module extension in rules_nixpkgs_java.
 bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "rules_java", version = "4.0.0")
+bazel_dep(name = "rules_java", version = "6.5.2")
 
 java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
 use_repo(java_toolchains, "remote_java_tools")

--- a/testing/posix/MODULE.bazel
+++ b/testing/posix/MODULE.bazel
@@ -24,7 +24,7 @@ bazel_dep(name = "rules_sh", version = "0.3.0")
 # TODO[AH] Remove these transitive dependencies once nixpkgs_java_configure has
 #   become a module extension in rules_nixpkgs_java.
 bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "rules_java", version = "4.0.0")
+bazel_dep(name = "rules_java", version = "6.5.2")
 
 java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
 use_repo(java_toolchains, "remote_java_tools")

--- a/testing/python/MODULE.bazel
+++ b/testing/python/MODULE.bazel
@@ -30,7 +30,7 @@ bazel_dep(name = "rules_cc", version = "0.0.4")
 # TODO[AH] Remove these transitive dependencies once nixpkgs_java_configure has
 #   become a module extension in rules_nixpkgs_java.
 bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "rules_java", version = "4.0.0")
+bazel_dep(name = "rules_java", version = "6.5.2")
 java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
 use_repo(java_toolchains, "remote_java_tools")
 

--- a/testing/rust/MODULE.bazel
+++ b/testing/rust/MODULE.bazel
@@ -31,7 +31,7 @@ bazel_dep(name = "rules_rust", version = "0.22.0")
 # TODO[AH] Remove these transitive dependencies once nixpkgs_java_configure has
 #   become a module extension in rules_nixpkgs_java.
 bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "rules_java", version = "4.0.0")
+bazel_dep(name = "rules_java", version = "6.5.2")
 
 java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
 use_repo(java_toolchains, "remote_java_tools")

--- a/toolchains/java/MODULE.bazel
+++ b/toolchains/java/MODULE.bazel
@@ -4,5 +4,5 @@ module(
 )
 
 bazel_dep(name = "rules_nixpkgs_core", version = "0.10.0")
-bazel_dep(name = "rules_java", version = "4.0.0")
+bazel_dep(name = "rules_java", version = "6.5.2")
 bazel_dep(name = "bazel_skylib", version = "1.0.3")

--- a/toolchains/java/local_java_repository.bzl
+++ b/toolchains/java/local_java_repository.bzl
@@ -14,7 +14,7 @@
 
 """Rules for importing and registering a local JDK."""
 
-load(":default_java_toolchain.bzl", "default_java_toolchain")
+load(":default_java_toolchain.bzl", "NONPREBUILT_TOOLCHAIN_CONFIGURATION", "default_java_toolchain")
 
 def _detect_java_version(repository_ctx, java_bin):
     properties_out = repository_ctx.execute([java_bin, "-XshowSettings:properties"]).stderr
@@ -99,10 +99,10 @@ def local_java_runtime(name, java_home, version, runtime_name = None, visibility
         for version in range(8, int(version) + 1):
             default_java_toolchain(
                 name = name + "_toolchain_java" + str(version),
+                configuration = NONPREBUILT_TOOLCHAIN_CONFIGURATION,
                 source_version = str(version),
                 target_version = str(version),
                 java_runtime = runtime_name,
-
                 exec_compatible_with = exec_compatible_with,
                 target_compatible_with = target_compatible_with,
             )


### PR DESCRIPTION
On NixOS we cannot use the pre-built `ijar` and `singlejar` tools as they are not statically build and fail to find the dynamic linker.

Fixes #278