### PR TITLE
Remove workaround for strict deps checking with nixpkgs JRE

### DIFF
--- a/.bazelrc.java
+++ b/.bazelrc.java
@@ -9,10 +9,4 @@ build --java_language_version=11
 build --tool_java_runtime_version=nixpkgs_java_11
 build --tool_java_language_version=11
 
-# The following lines provide a workaround for a test failure in on the Java
-# toolchain on MacOS 11, documented here: https://github.com/tweag/rules_nixpkgs/issues/299.
-# They should be removed as soon as that issue has been resolved.
-build --enable_platform_specific_config
-build:macos --experimental_strict_java_deps=warn
-
 # vim: ft=conf


### PR DESCRIPTION
The JRE we get from nixpkgs is now recent enough and strict deps checking works properly.

Fixes #299