### PR TITLE
chore: use `cgrindel/gha_join_jobs` to consolidate all CI job statuses

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -11,7 +11,7 @@ on:
     - cron: '1 11 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -10,15 +10,11 @@ on:
   schedule:
     - cron: '1 11 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
-  cancel-running-workflows:
-    name: Cancel running workflows
-    runs-on: ubuntu-latest
-    steps:
-      - name: cancel running workflows
-        uses: styfle/cancel-workflow-action@0.12.0
-        with:
-          access_token: ${{ github.token }}
   test-nixpkgs:
     name: Build & Test - Nixpkgs - ${{ matrix.bzlmodEnabled && 'bzlmod' || 'workspace' }} ${{ matrix.withNixRemote && '- NixRemote ' || '' }}- ${{ matrix.os }}
     strategy:
@@ -144,3 +140,14 @@ jobs:
             nix-shell --command 'bazel run --crosstool_top=@nixpkgs_config_cc//:toolchain :hello'
             popd
           fi
+
+  all_ci_tests:
+    runs-on: ubuntu-latest
+    needs:
+      - test-nixpkgs
+      - test-examples
+    if: ${{ always() }}
+    steps:
+      - uses: cgrindel/gha_join_jobs@794a2d117251f22607f1aab937d3fd3eaaf9a2f5 # v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Also, I switched to using GitHub's `concurrency` feature.