### PR TITLE
Add SystemConfiguration to the CC wrapper

### DIFF
--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -38,6 +38,7 @@ let
         echo "-F${CoreServices}/Library/Frameworks" >> $out/nix-support/cc-cflags
         echo "-F${Security}/Library/Frameworks" >> $out/nix-support/cc-cflags
         echo "-F${Foundation}/Library/Frameworks" >> $out/nix-support/cc-cflags
+        echo "-F${SystemConfiguration}/Library/Frameworks" >> $out/nix-support/cc-cflags
         echo "-L${pkgs.llvmPackages.libcxx}/lib" >> $out/nix-support/cc-cflags
         echo "-L${pkgs.llvmPackages.libcxxabi}/lib" >> $out/nix-support/cc-cflags
         echo "-L${pkgs.libiconv}/lib" >> $out/nix-support/cc-cflags


### PR DESCRIPTION
Noticed that some rust builds were failing with linker errors after we added the `reqwest` crate. Turns out this was missing from the wrapper - patching this in locally fixed it.