### PR TITLE
toolchains/cc: Fix process getting killed on aarch64-darwin during li…

### DIFF
--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -60,13 +60,23 @@ let
           name = "bazel-${cc.name}-wrapper";
           # XXX: `gcov` is missing in `/bin`.
           #   It exists in `stdenv.cc.cc` but that collides with `stdenv.cc`.
-          paths = [ cc cc.bintools ] ++ pkgs.lib.optional pkgs.stdenv.isDarwin pkgs.darwin.cctools;
+          paths = [ cc cc.bintools ];
           pathsToLink = [ "/bin" ];
           passthru = {
             inherit (cc) isClang targetPrefix;
             orignalName = cc.name;
           };
+        } // (pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+          # only add tools from darwin.cctools, but don't overwrite existing tools
+          postBuild = ''
+            for tool in libtool objdump; do
+               if [[ ! -e $out/bin/$tool ]]; then
+                 ln -s -t $out/bin ${pkgs.darwin.cctools}/bin/$tool
+               fi
+            done
+          '';
         }
+        )
       )
   ;
 in


### PR DESCRIPTION
…nking

On aarch64 Darwin, when using a nixpkgs provided cc toolchain, we have [seen][1] the linking step to fail as the process got killed:

```
bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/rules_haskell/haskell/ghc_wrapper: line 80: 90734 Killed: 9
               "${compile_flags[@]}" "${extra_args[@]}" 2>&1
     90736 Done                    | drop_loaded_and_warning 1>&2
```

More specifically this happened when trying to add an rpath to a dylib calling the `install_name_tool`, but running the same command manually succeeded.

This seems to be caused by mixing different tools from stdenv.cc and darwin.cctools, especially the fact that the tools from the latter overwrote tools from the former.

Only add missing tools not provided by the current cc toolchain from the darwin.cctools package instead.

[1]: https://github.com/tweag/rules_haskell/issues/2101