### PR TITLE
Add `sigtool` to the bazel cc wrapper

### DIFF
--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -60,7 +60,7 @@ let
           name = "bazel-${cc.name}-wrapper";
           # XXX: `gcov` is missing in `/bin`.
           #   It exists in `stdenv.cc.cc` but that collides with `stdenv.cc`.
-          paths = [ cc cc.bintools ];
+          paths = [ cc cc.bintools ] ++ pkgs.lib.optional pkgs.stdenv.isDarwin pkgs.darwin.sigtool;
           pathsToLink = [ "/bin" ];
           passthru = {
             inherit (cc) isClang targetPrefix;


### PR DESCRIPTION
This is needed on Darwin when (re-)signing binaries.

This failed when using a nixpgks configured cc like this:
```
 Traceback (most recent call last):
  File "/private/var/tmp/_bazel_runner/d1e3bdaa0c37ce8d00ecff62b05849c3/sandbox/processwrapper-sandbox/149/execroot/rules_haskell/bazel-out/darwin-opt-exec-C7777A24/bin/haskell/cc_wrapper-python.runfiles/rules_haskell/haskell/cc_wrapper.py", line 1161, in <module>
    main()
  File "/private/var/tmp/_bazel_runner/d1e3bdaa0c37ce8d00ecff62b05849c3/sandbox/processwrapper-sandbox/149/execroot/rules_haskell/bazel-out/darwin-opt-exec-C7777A24/bin/haskell/cc_wrapper-python.runfiles/rules_haskell/haskell/cc_wrapper.py", line 96, in main
    link(parsed.output, parsed.libraries, parsed.rpaths, parsed.args)
  File "/private/var/tmp/_bazel_runner/d1e3bdaa0c37ce8d00ecff62b05849c3/sandbox/processwrapper-sandbox/149/execroot/rules_haskell/bazel-out/darwin-opt-exec-C7777A24/bin/haskell/cc_wrapper-python.runfiles/rules_haskell/haskell/cc_wrapper.py", line 580, in link
    darwin_rewrite_load_commands(darwin_rewrites, output)
  File "/private/var/tmp/_bazel_runner/d1e3bdaa0c37ce8d00ecff62b05849c3/sandbox/processwrapper-sandbox/149/execroot/rules_haskell/bazel-out/darwin-opt-exec-C7777A24/bin/haskell/cc_wrapper-python.runfiles/rules_haskell/haskell/cc_wrapper.py", line 939, in darwin_rewrite_load_commands
    subprocess.check_call([CODESIGN] + ["-f", "-s", "-"] + [f"{output}.resign"], env = {'CODESIGN_ALLOCATE': CODESIGN_ALLOCATE})
  File "/nix/store/cdbhdah4qillzy7z9rsi3svbarwm8a6i-python3-3.11.6/lib/python3.11/subprocess.py", line 408, in check_call
    retcode = call(*popenargs, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/cdbhdah4qillzy7z9rsi3svbarwm8a6i-python3-3.11.6/lib/python3.11/subprocess.py", line 389, in call
    with Popen(*popenargs, **kwargs) as p:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/cdbhdah4qillzy7z9rsi3svbarwm8a6i-python3-3.11.6/lib/python3.11/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/nix/store/cdbhdah4qillzy7z9rsi3svbarwm8a6i-python3-3.11.6/lib/python3.11/subprocess.py", line 1950, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/nix/store/ckwiyngb33gsfahpshb6n9476mdkc0h4-bazel-clang-wrapper-16.0.6-wrapper/bin/codesign'
```

CI passed for rules_haskell including these changes: https://github.com/tweag/rules_haskell/actions/runs/8450680413

(except format & lint and bzlmod jobs, but that's expected)