### PR TITLE
add `compatibility_level` to `core/MODULE.bazel` before publish to BCR

### DIFF
--- a/core/MODULE.bazel
+++ b/core/MODULE.bazel
@@ -1,6 +1,7 @@
 module(
     name = "rules_nixpkgs_core",
     version = "0.11.0",
+    compatibility_level = 1,
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")


### PR DESCRIPTION
[`add_module.py`](https://github.com/bazelbuild/bazel-central-registry/tree/main/tools#add_modulepy) shouts the following at me.

```
BcrValidationResult.FAILED: Checked in MODULE.bazel file doesn't match the one in the extracted and patched sources.
Please fix the MODULE.bazel file or you can add the following patch to rules_nixpkgs_core@0.11.0:
    --- MODULE.bazel
    +++ MODULE.bazel
    @@ -1,15 +1,7 @@
     module(
         name = "rules_nixpkgs_core",
         version = "0.11.0",
    +    compatibility_level = 1,
     )
```

now i am worried that `compatibility_level` is required in `MODULE.bazel` now. does anybody know more?