### PR TITLE
wip: allow building of wasm targets

### DIFF
--- a/examples/toolchains/rust/BUILD
+++ b/examples/toolchains/rust/BUILD
@@ -1,4 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@rules_rust//wasm_bindgen:defs.bzl", "rust_wasm_bindgen")
 load("@crate_index//:defs.bzl", "all_crate_deps")
 
 exports_files([
@@ -10,5 +11,12 @@ exports_files([
 rust_binary(
     name = "hello",
     srcs = ["hello.rs"],
-    deps = all_crate_deps(normal = True),
+    deps = [], # all_crate_deps(normal = True),
+    edition = "2021",
+)
+
+rust_wasm_bindgen(
+    name = "wasm",
+    target = "web",
+    wasm_file = ":hello",
 )

--- a/examples/toolchains/rust/WORKSPACE
+++ b/examples/toolchains/rust/WORKSPACE
@@ -43,11 +43,19 @@ nixpkgs_cc_configure(
     ],
 )
 
-load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/rust.bzl", "nixpkgs_rust_configure")
+load("@io_tweag_rules_nixpkgs//nixpkgs:toolchains/rust.bzl", "nixpkgs_rust_configure", "nixpkgs_rust_wasm_configure")
 
 nixpkgs_rust_configure(
     repository = "@nixpkgs",
     name = "nix_rust",
+    nix_file_deps = [
+        "//:nixpkgs.json"
+    ],
+)
+
+nixpkgs_rust_wasm_configure(
+    repository = "@nixpkgs",
+    name = "nix_wasm_rust",
     nix_file_deps = [
         "//:nixpkgs.json"
     ],
@@ -65,6 +73,13 @@ nixpkgs_package(
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
 rust_repositories()
+
+load("@rules_rust//wasm_bindgen:repositories.bzl", "rust_wasm_bindgen_dependencies", "rust_wasm_bindgen_register_toolchains")
+
+rust_wasm_bindgen_dependencies()
+
+rust_wasm_bindgen_register_toolchains()
+
 
 # crate_universe as a way of governing deps
 load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")

--- a/examples/toolchains/rust/hello.rs
+++ b/examples/toolchains/rust/hello.rs
@@ -1,6 +1,7 @@
 fn main() {
-  println!(
-    "Hello world from {:?}",
-    openssl::version::version()
-  );
+    println!(
+        "Hello world from {:?}",
+        String::from("wasm??"),
+        // openssl::version::version()
+    );
 }

--- a/nixpkgs/toolchains/rust.bzl
+++ b/nixpkgs/toolchains/rust.bzl
@@ -1,5 +1,8 @@
 # alias to Bazel module `toolchains/go`
 
 load("@rules_nixpkgs_rust//:rust.bzl", _nixpkgs_rust_configure = "nixpkgs_rust_configure")
+load("@rules_nixpkgs_rust//:wasm.bzl", _nixpkgs_rust_wasm_configure = "nixpkgs_rust_wasm_configure")
 
 nixpkgs_rust_configure = _nixpkgs_rust_configure
+nixpkgs_rust_wasm_configure = _nixpkgs_rust_wasm_configure
+

--- a/toolchains/rust/BUILD.bazel
+++ b/toolchains/rust/BUILD.bazel
@@ -10,7 +10,7 @@ filegroup(
 
 bzl_library(
     name = "rust",
-    srcs = ["//:rust.bzl"],
+    srcs = ["//:rust.bzl", "//:wasm.bzl"],
     deps = [
         "@rules_nixpkgs_core//:nixpkgs",
     ],

--- a/toolchains/rust/wasm.bzl
+++ b/toolchains/rust/wasm.bzl
@@ -1,0 +1,219 @@
+"""<!-- Edit the docstring in `toolchains/rust/rust.bzl` and run `bazel run //docs:update-README.md` to change this repository's `README.md`. -->
+
+Rules for importing a Rust toolchain from Nixpkgs.
+
+# Rules
+
+* [nixpkgs_rust_wasm_configure](#nixpkgs_rust_configure)
+"""
+
+load("@rules_nixpkgs_core//:nixpkgs.bzl", "nixpkgs_package")
+load("@rules_nixpkgs_core//:util.bzl", "ensure_constraints")
+
+# Adapted from rules_rust toolchain BUILD:
+# https://github.com/bazelbuild/rules_rust/blob/fd436df9e2d4ac1b234ca5e969e34a4cb5891910/rust/private/repository_utils.bzl#L17-L46
+# Nix generation is used to dynamically compute both Linux and Darwin environments
+_rust_nix_contents = """\
+let
+    pkgs = import <nixpkgs> {{
+        config = {{}};
+        overrides = [];
+    }};
+    rust = pkgs.rust;
+    os = rust.toTargetOs pkgs.stdenv.targetPlatform;
+    build-triple = rust.toRustTargetSpec pkgs.stdenv.buildPlatform;
+    target-triple = rust.toRustTargetSpec pkgs.stdenv.targetPlatform;
+    rustc-wasm32 = if os == "macos" then
+      # rustc on MacOS expects the `strip` binary in PATH, create a wrapper adding the bin
+      # folder from `binutils` to the PATH
+      pkgs.symlinkJoin
+        {{
+          name = "rustc-wasm32";
+          paths = [ pkgs.rustc-wasm32 ];
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+          postBuild = ''
+            wrapProgram $out/bin/rustc --suffix PATH : ${{pkgs.binutils}}/bin
+          '';
+        }}
+      else pkgs.rustc-wasm32;
+    rustdoc = pkgs.stdenv.mkDerivation {{
+        name = "rustdoc";
+        src = pkgs.rustc;
+        phases = ["unpackPhase"];
+        unpackPhase = ''
+            mkdir -p $out/bin
+            cp $src/bin/rustdoc $out/bin/
+        '';
+    }};
+    binary-ext = "";
+    staticlib-ext = ".a";
+    dylib-ext = if os == "macos" then ".dylib" else ".so";
+in
+pkgs.buildEnv {{
+    extraOutputsToInstall = ["out" "bin" "lib"];
+    name = "bazel-rust-wasm-toolchain";
+    paths = [ rustc-wasm32 rustdoc pkgs.rustfmt pkgs.cargo pkgs.clippy ];
+    postBuild = ''
+        cat <<EOF > $out/BUILD
+        filegroup(
+            name = "rustc",
+            srcs = ["bin/rustc"],
+            visibility = ["//visibility:public"],
+        )
+
+        filegroup(
+            name = "rustfmt",
+            srcs = ["bin/rustfmt"],
+            visibility = ["//visibility:public"],
+        )
+
+        filegroup(
+            name = "cargo",
+            srcs = ["bin/cargo"],
+            visibility = ["//visibility:public"],
+        )
+
+        filegroup(
+            name = "clippy_driver",
+            srcs = ["bin/clippy-driver"],
+            visibility = ["//visibility:public"],
+        )
+
+        filegroup(
+            name = "rustc_lib",
+            srcs = glob(
+                [
+                    "bin/*.so",
+                    "lib/*.so",
+                    "lib/rustlib/*/codegen-backends/*.so",
+                    "lib/rustlib/*/codegen-backends/*.dylib",
+                    "lib/rustlib/*/bin/rust-lld",
+                    "lib/rustlib/*/lib/*.so",
+                    "lib/rustlib/*/lib/*.dylib",
+                ],
+                allow_empty = True,
+            ),
+            visibility = ["//visibility:public"],
+        )
+
+        load("@rules_rust//rust:toolchain.bzl", "rust_stdlib_filegroup")
+        rust_stdlib_filegroup(
+            name = "rust_std",
+            srcs = glob(
+                [
+                    "lib/rustlib/*/lib/*.rlib",
+                    "lib/rustlib/*/lib/*.so",
+                    "lib/rustlib/*/lib/*.dylib",
+                    "lib/rustlib/*/lib/*.a",
+                    "lib/rustlib/*/lib/self-contained/**",
+                ],
+                # Some patterns (e.g. `lib/*.a`) don't match anything, see https://github.com/bazelbuild/rules_rust/pull/245
+                allow_empty = True,
+            ),
+            visibility = ["//visibility:public"],
+        )
+
+        filegroup(
+            name = "rust_doc",
+            srcs = ["bin/rustdoc"],
+            visibility = ["//visibility:public"],
+        )
+
+        load('@rules_rust//rust:toolchain.bzl', 'rust_toolchain')
+        rust_toolchain(
+            name = "rust_wasm_nix_impl",
+            rust_doc = ":rust_doc",
+            rust_std = ":rust_std",
+            rustc = ":rustc",
+            rustfmt = ":rustfmt",
+            cargo = ":cargo",
+            clippy_driver = ":clippy_driver",
+            rustc_lib = ":rustc_lib",
+            binary_ext = "${{binary-ext}}",
+            staticlib_ext = "${{staticlib-ext}}",
+            dylib_ext = "${{dylib-ext}}",
+            exec_triple = "${{build-triple}}",
+            default_edition = "{default_edition}",
+            stdlib_linkflags = {stdlib_linkflags},
+            visibility = ["//visibility:public"],
+            target_triple = "wasm32-unknown-unknown",
+        )
+
+        EOF
+    '';
+}}
+"""
+
+_rust_nix_toolchain = """
+toolchain(
+    name = "rust_wasm_nix",
+    toolchain = "@{toolchain_repo}//:rust_wasm_nix_impl",
+    toolchain_type = "@rules_rust//rust:toolchain",
+    exec_compatible_with = {exec_constraints},
+    target_compatible_with = [
+        "@platforms//cpu:wasm32",
+        "@platforms//os:none",
+    ],
+)
+"""
+
+def _nixpkgs_rust_toolchain_impl(repository_ctx):
+    exec_constraints, target_constraints = ensure_constraints(repository_ctx)
+    repository_ctx.file(
+        "BUILD.bazel",
+        executable = False,
+        content = _rust_nix_toolchain.format(
+            toolchain_repo = repository_ctx.attr.toolchain_repo,
+            exec_constraints = exec_constraints,
+            target_constraints = target_constraints,
+        ),
+    )
+
+_nixpkgs_rust_toolchain = repository_rule(
+    _nixpkgs_rust_toolchain_impl,
+    attrs = {
+        "toolchain_repo": attr.string(),
+        "exec_constraints": attr.string_list(),
+        "target_constraints": attr.string_list(),
+    },
+)
+
+def nixpkgs_rust_wasm_configure(
+        name = "nixpkgs_rust",
+        default_edition = "2018",
+        repository = None,
+        repositories = {},
+        nix_file = None,
+        nix_file_deps = None,
+        nix_file_content = None,
+        nixopts = [],
+        fail_not_supported = True,
+        quiet = False,
+        exec_constraints = None,
+        target_constraints = None,
+        register = True):
+    if not nix_file and not nix_file_content:
+        nix_file_content = _rust_nix_contents.format(
+            default_edition = default_edition,
+            stdlib_linkflags = '["-lpthread", "-ldl"]',
+        )
+
+    nixpkgs_package(
+        name = name,
+        repository = repository,
+        repositories = repositories,
+        nix_file = nix_file,
+        nix_file_deps = nix_file_deps,
+        nix_file_content = nix_file_content,
+        nixopts = nixopts,
+        fail_not_supported = fail_not_supported,
+        quiet = quiet,
+    )
+    _nixpkgs_rust_toolchain(
+        name = name + "_toolchain",
+        toolchain_repo = name,
+        exec_constraints = exec_constraints,
+        target_constraints = target_constraints,
+    )
+    if register:
+        native.register_toolchains("@{}_toolchain//:rust_wasm_nix".format(name))


### PR DESCRIPTION
**WIP** attempt(s) to address #494.

Create a new toolchain builder that uses the `rustc-wasm32` package instead than the `rustc` package. 

The `rustc-wasm32` package doesn't provide `rustdoc` so I created a derivation to extract that from the regular `rustc` target. This shouldn't cause any issues.

Bazel selects the correct toolchain, but still errors out with the following:

```shell
❯ bazel build --config=nix //:wasm --verbose_failures
INFO: Analyzed target //:wasm (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
ERROR: /home/grawlix/repos/github.com/snapbug/rules_nixpkgs/examples/toolchains/rust/BUILD:11:12: Compiling Rust bin hello (1 files) failed: (Exit 1): process_wrapper failed: error executing command (from target //:hello)
  (cd /home/grawlix/.cache/bazel/_bazel_grawlix/e607e8e55d4b1c2cd07980276d90b4b7/sandbox/linux-sandbox/41/execroot/__main__ && \
  exec env - \
    CARGO_CFG_TARGET_ARCH=wasm32 \
    CARGO_CFG_TARGET_OS=unknown \
    CARGO_CRATE_NAME=hello \
    CARGO_MANIFEST_DIR='${pwd}' \
    CARGO_PKG_AUTHORS='' \
    CARGO_PKG_DESCRIPTION='' \
    CARGO_PKG_HOMEPAGE='' \
    CARGO_PKG_NAME=hello \
    CARGO_PKG_VERSION=0.0.0 \
    CARGO_PKG_VERSION_MAJOR=0 \
    CARGO_PKG_VERSION_MINOR=0 \
    CARGO_PKG_VERSION_PATCH=0 \
    CARGO_PKG_VERSION_PRE='' \
    SYSROOT=bazel-out/k8-fastbuild-ST-38b09129ed05/bin/external/nix_wasm_rust/rust_wasm_nix_impl \
  bazel-out/k8-opt-exec-C7777A24-ST-da94b34a892a/bin/external/rules_rust/util/process_wrapper/process_wrapper --subst 'pwd=${pwd}' -- bazel-out/k8-fastbuild-ST-38b09129ed05/bin/external/nix_wasm_rust/rust_wasm_nix_impl/bin/rustc hello.rs '--crate-name=hello' '--crate-type=bin' '--error-format=human' '--out-dir=bazel-out/k8-fastbuild-ST-38b09129ed05/bin' '--codegen=opt-level=0' '--codegen=debuginfo=0' '--remap-path-prefix=${pwd}=' '--emit=dep-info,link' '--color=always' '--target=wasm32-unknown-unknown' -L bazel-out/k8-fastbuild-ST-38b09129ed05/bin/external/nix_wasm_rust/rust_wasm_nix_impl/lib/rustlib/wasm32-unknown-unknown/lib -L bazel-out/k8-fastbuild-ST-38b09129ed05/bin/external/nix_wasm_rust/rust_wasm_nix_impl/lib/rustlib/x86_64-unknown-linux-gnu/lib '--edition=2021' '--sysroot=bazel-out/k8-fastbuild-ST-38b09129ed05/bin/external/nix_wasm_rust/rust_wasm_nix_impl')
# Configuration: 0590131d7658b76a08b19d13b2b4ddbfb70bcfab1a21c0745038366e0d666ffe
# Execution platform: @rules_nixpkgs_core//platforms:host

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
error: linker `rust-lld` not found
  |
  = note: No such file or directory (os error 2)

error: aborting due to previous error

Target //:wasm failed to build
INFO: Elapsed time: 0.168s, Critical Path: 0.08s
INFO: 5 processes: 5 internal.
FAILED: Build did NOT complete successfully
```

I think the way to make progress here is to do a similar thing as the `rustdoc` fix for `rust-lld`, although that might be a bit tougher [as the `rust-lld` binary seems to be nested in the `lib` content](https://github.com/tweag/rules_nixpkgs/blob/126e9f66b833337be2c35103ce46ab66b4e44799/toolchains/rust/rust.bzl#L78). So have to investigate the full-path here, or alternatives.