### PR TITLE
make `rules_nixpkgs_java` depend on `remote_java_tools` properly

### DIFF
--- a/testing/cc/MODULE.bazel
+++ b/testing/cc/MODULE.bazel
@@ -26,9 +26,6 @@ bazel_dep(name = "rules_cc", version = "0.0.4")
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_java", version = "6.5.2")
 
-java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
-use_repo(java_toolchains, "remote_java_tools")
-
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
 use_repo(non_module_deps, "nixpkgs")
 use_repo(non_module_deps, "nixpkgs_config_cc")

--- a/testing/go-bzlmod/MODULE.bazel
+++ b/testing/go-bzlmod/MODULE.bazel
@@ -32,9 +32,6 @@ bazel_dep(name = "rules_cc", version = "0.0.4")
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_java", version = "6.5.2")
 
-java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
-use_repo(java_toolchains, "remote_java_tools")
-
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
 use_repo(non_module_deps, "nixpkgs")
 use_repo(non_module_deps, "nixpkgs_go_sdk_toolchains")

--- a/testing/java/MODULE.bazel
+++ b/testing/java/MODULE.bazel
@@ -19,9 +19,6 @@ bazel_dep(name = "bazel_skylib", version = "1.0.3")
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_java", version = "6.5.2")
 
-java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
-use_repo(java_toolchains, "remote_java_tools")
-
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
 use_repo(non_module_deps, "nixpkgs")
 use_repo(non_module_deps, "nixpkgs_java_runtime")

--- a/testing/nodejs/MODULE.bazel
+++ b/testing/nodejs/MODULE.bazel
@@ -33,9 +33,6 @@ bazel_dep(name = "rules_nodejs", version = "5.5.3")
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_java", version = "6.5.2")
 
-java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
-use_repo(java_toolchains, "remote_java_tools")
-
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
 use_repo(non_module_deps, "nixpkgs")
 [

--- a/testing/posix/MODULE.bazel
+++ b/testing/posix/MODULE.bazel
@@ -26,9 +26,6 @@ bazel_dep(name = "rules_sh", version = "0.3.0")
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_java", version = "6.5.2")
 
-java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
-use_repo(java_toolchains, "remote_java_tools")
-
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
 use_repo(non_module_deps, "nixpkgs")
 use_repo(non_module_deps, "nixpkgs_sh_posix_config")

--- a/testing/python/MODULE.bazel
+++ b/testing/python/MODULE.bazel
@@ -31,8 +31,6 @@ bazel_dep(name = "rules_cc", version = "0.0.4")
 #   become a module extension in rules_nixpkgs_java.
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_java", version = "6.5.2")
-java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
-use_repo(java_toolchains, "remote_java_tools")
 
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
 

--- a/testing/rust/MODULE.bazel
+++ b/testing/rust/MODULE.bazel
@@ -33,9 +33,6 @@ bazel_dep(name = "rules_rust", version = "0.35.0")
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_java", version = "6.5.2")
 
-java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
-use_repo(java_toolchains, "remote_java_tools")
-
 # we must use the extension, and we must call the `toolchain` tag
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(

--- a/toolchains/java/MODULE.bazel
+++ b/toolchains/java/MODULE.bazel
@@ -6,3 +6,6 @@ module(
 bazel_dep(name = "rules_nixpkgs_core", version = "0.11.1")
 bazel_dep(name = "rules_java", version = "6.5.2")
 bazel_dep(name = "bazel_skylib", version = "1.0.3")
+
+toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
+use_repo(toolchains, "remote_java_tools")

--- a/toolchains/java/default_java_toolchain.bzl
+++ b/toolchains/java/default_java_toolchain.bzl
@@ -55,13 +55,13 @@ DEFAULT_JAVACOPTS = [
 # jdk.compiler module, and jvm_opts
 _BASE_TOOLCHAIN_CONFIGURATION = dict(
     forcibly_disable_header_compilation = False,
-    genclass = ["@remote_java_tools//:GenClass"],
-    header_compiler = ["@remote_java_tools//:TurbineDirect"],
-    header_compiler_direct = ["@remote_java_tools//:TurbineDirect"],
+    genclass = [Label("@remote_java_tools//:GenClass")],
+    header_compiler = [Label("@remote_java_tools//:TurbineDirect")],
+    header_compiler_direct = [Label("@remote_java_tools//:TurbineDirect")],
     ijar = ["@bazel_tools//tools/jdk:ijar"],
-    javabuilder = ["@remote_java_tools//:JavaBuilder"],
+    javabuilder = [Label("@remote_java_tools//:JavaBuilder")],
     javac_supports_workers = True,
-    jacocorunner = "@remote_java_tools//:jacoco_coverage_runner_filegroup",
+    jacocorunner = Label("@remote_java_tools//:jacoco_coverage_runner_filegroup"),
     jvm_opts = BASE_JDK9_JVM_OPTS,
     misc = DEFAULT_JAVACOPTS,
     singlejar = ["@bazel_tools//tools/jdk:singlejar"],
@@ -101,7 +101,7 @@ DEFAULT_TOOLCHAIN_CONFIGURATION = dict(
 # However it does allow using a wider range of `--host_javabase`s, including
 # versions newer than the current JDK.
 VANILLA_TOOLCHAIN_CONFIGURATION = dict(
-    javabuilder = ["@remote_java_tools//:VanillaJavaBuilder"],
+    javabuilder = [Label("@remote_java_tools//:VanillaJavaBuilder")],
     jvm_opts = [],
 )
 
@@ -134,8 +134,8 @@ NONPREBUILT_TOOLCHAIN_CONFIGURATION = dict(
         # Turbine is not a worker and parallel GC is faster for short-lived programs.
         "-XX:+UseParallelGC",
     ],
-    ijar = ["@remote_java_tools//:ijar_cc_binary"],
-    singlejar = ["@remote_java_tools//:singlejar_cc_bin"],
+    ijar = [Label("@remote_java_tools//:ijar_cc_binary")],
+    singlejar = [Label("@remote_java_tools//:singlejar_cc_bin")],
     java_runtime = "@bazel_tools//tools/jdk:remote_jdk11",
 )
 


### PR DESCRIPTION
this fixes the issue that users of `rules_nixpkgs_java` need to depend on a dependency of `rules_nixpkgs_java`, that is on `remote_java_tools`. examples are [`8e44cce`](https://github.com/tweag/rules_nixpkgs/pull/497/commits/8e44ccea8442bfb3b3a3386494a0cf90f088c295).