### PR TITLE
support `@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type`

### DIFF
--- a/toolchains/java/local_java_repository.bzl
+++ b/toolchains/java/local_java_repository.bzl
@@ -94,6 +94,12 @@ def local_java_runtime(name, java_home, version, runtime_name = None, visibility
         toolchain_type = "@bazel_tools//tools/jdk:runtime_toolchain_type",
         toolchain = runtime_name,
     )
+    native.toolchain(
+        name = "bootstrap_runtime_toolchain_definition",
+        target_settings = [":%s_settings_alias" % name],
+        toolchain_type = "@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type",
+        toolchain = runtime_name,
+    )
 
     if type(version) == type("") and version.isdigit() and int(version) > 8:
         for version in range(8, int(version) + 1):


### PR DESCRIPTION
thanks to @alexflurieagility.

fixes https://github.com/tweag/rules_nixpkgs/issues/477.

this contains https://github.com/tweag/rules_nixpkgs/pull/503.

**to do**
- [ ] document which versions this breaks compatibility with and the new minimally required versions (of bazel, `rules_java`,...)