### PR TITLE
add module extension for nodejs toolchain

### DIFF
--- a/testing/nodejs/MODULE.bazel
+++ b/testing/nodejs/MODULE.bazel
@@ -28,6 +28,10 @@ bazel_dep(name = "bazel_skylib", version = "1.0.3")
 bazel_dep(name = "rules_cc", version = "0.0.4")
 bazel_dep(name = "rules_nodejs", version = "5.5.3")
 
+nix_repo = use_extension("@rules_nixpkgs_core//extensions:repository.bzl", "nix_repo")
+nix_repo.default(name = "nixpkgs")
+use_repo(nix_repo, "nixpkgs")
+
 nix_nodejs = use_extension("@rules_nixpkgs_nodejs//extensions:toolchain.bzl", "nix_nodejs")
 use_repo(nix_nodejs, "nixpkgs_nodejs_toolchains")
 register_toolchains("@nixpkgs_nodejs_toolchains//:all")
@@ -38,7 +42,6 @@ bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_java", version = "6.5.2")
 
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
-use_repo(non_module_deps, "nixpkgs")
 [
     (
         use_repo(non_module_deps, "nixpkgs_nodejs_{}_{}_toolchain".format(os, arch)),

--- a/testing/nodejs/MODULE.bazel
+++ b/testing/nodejs/MODULE.bazel
@@ -42,15 +42,6 @@ bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_java", version = "6.5.2")
 
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
-[
-    (
-        use_repo(non_module_deps, "nixpkgs_nodejs_{}_{}_toolchain".format(os, arch)),
-        register_toolchains("@nixpkgs_nodejs_{}_{}_toolchain//:all".format(os, arch)),
-    )
-    for os in ["linux", "darwin"]
-    for arch in ["amd64", "arm64"]
-]
-
 use_repo(non_module_deps, "nixpkgs_config_cc")
 use_repo(non_module_deps, "nixpkgs_config_cc_info")
 use_repo(non_module_deps, "nixpkgs_config_cc_toolchains")

--- a/testing/nodejs/MODULE.bazel
+++ b/testing/nodejs/MODULE.bazel
@@ -28,6 +28,10 @@ bazel_dep(name = "bazel_skylib", version = "1.0.3")
 bazel_dep(name = "rules_cc", version = "0.0.4")
 bazel_dep(name = "rules_nodejs", version = "5.5.3")
 
+nix_nodejs = use_extension("@rules_nixpkgs_nodejs//extensions:toolchain.bzl", "nix_nodejs")
+use_repo(nix_nodejs, "nixpkgs_nodejs_toolchains")
+register_toolchains("@nixpkgs_nodejs_toolchains//:all")
+
 # TODO[AH] Remove these transitive dependencies once nixpkgs_java_configure has
 #   become a module extension in rules_nixpkgs_java.
 bazel_dep(name = "platforms", version = "0.0.4")

--- a/testing/nodejs/MODULE.bazel
+++ b/testing/nodejs/MODULE.bazel
@@ -32,10 +32,6 @@ nix_repo = use_extension("@rules_nixpkgs_core//extensions:repository.bzl", "nix_
 nix_repo.default(name = "nixpkgs")
 use_repo(nix_repo, "nixpkgs")
 
-nix_nodejs = use_extension("@rules_nixpkgs_nodejs//extensions:toolchain.bzl", "nix_nodejs")
-use_repo(nix_nodejs, "nixpkgs_nodejs_toolchains")
-register_toolchains("@nixpkgs_nodejs_toolchains//:all")
-
 # TODO[AH] Remove these transitive dependencies once nixpkgs_java_configure has
 #   become a module extension in rules_nixpkgs_java.
 bazel_dep(name = "platforms", version = "0.0.4")

--- a/testing/nodejs/tests/nixpkgs_repositories.bzl
+++ b/testing/nodejs/tests/nixpkgs_repositories.bzl
@@ -4,11 +4,12 @@ load("@rules_nixpkgs_java//:java.bzl", "nixpkgs_java_configure")
 load("@rules_nixpkgs_nodejs//:nodejs.bzl", "nixpkgs_nodejs_configure_platforms")
 
 def nixpkgs_repositories(*, bzlmod):
-    nixpkgs_local_repository(
-        name = "nixpkgs",
-        nix_file = "//:nixpkgs.nix",
-        nix_file_deps = ["//:flake.lock"],
-    )
+    if not bzlmod:
+        nixpkgs_local_repository(
+            name = "nixpkgs",
+            nix_file = "//:nixpkgs.nix",
+            nix_file_deps = ["//:flake.lock"],
+        )
 
     nixpkgs_cc_configure(
         name = "nixpkgs_config_cc",

--- a/testing/nodejs/tests/nixpkgs_repositories.bzl
+++ b/testing/nodejs/tests/nixpkgs_repositories.bzl
@@ -11,6 +11,12 @@ def nixpkgs_repositories(*, bzlmod):
             nix_file_deps = ["//:flake.lock"],
         )
 
+        nixpkgs_nodejs_configure_platforms(
+            name = "nixpkgs_nodejs",
+            repository = "@nixpkgs",
+            register = not bzlmod,
+        )
+
     nixpkgs_cc_configure(
         name = "nixpkgs_config_cc",
         repository = "@nixpkgs",
@@ -25,10 +31,4 @@ def nixpkgs_repositories(*, bzlmod):
         register = not bzlmod,
         toolchain_name = "nixpkgs_java",
         toolchain_version = "11",
-    )
-
-    nixpkgs_nodejs_configure_platforms(
-        name = "nixpkgs_nodejs",
-        repository = "@nixpkgs",
-        register = not bzlmod,
     )

--- a/toolchains/nodejs/BUILD.bazel
+++ b/toolchains/nodejs/BUILD.bazel
@@ -16,7 +16,7 @@ bzl_library(
     srcs = ["//:nodejs.bzl"],
     deps = [
         "@rules_nixpkgs_core//:nixpkgs",
-        "@rules_nixpkgs_nodejs//private:common",
         "@rules_nodejs//nodejs:bzl",
+        "//private:common",
     ],
 )

--- a/toolchains/nodejs/BUILD.bazel
+++ b/toolchains/nodejs/BUILD.bazel
@@ -4,7 +4,10 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "srcs",
-    srcs = glob(["**"]),
+    srcs = glob(["**"]) + [
+        "//extensions:srcs",
+        "//private:srcs",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/toolchains/nodejs/BUILD.bazel
+++ b/toolchains/nodejs/BUILD.bazel
@@ -13,6 +13,7 @@ bzl_library(
     srcs = ["//:nodejs.bzl"],
     deps = [
         "@rules_nixpkgs_core//:nixpkgs",
+        "@rules_nixpkgs_nodejs//private:common",
         "@rules_nodejs//nodejs:bzl",
     ],
 )

--- a/toolchains/nodejs/MODULE.bazel
+++ b/toolchains/nodejs/MODULE.bazel
@@ -4,5 +4,10 @@ module(
 )
 
 bazel_dep(name = "rules_nixpkgs_core", version = "0.11.1")
+bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_nodejs", version = "5.5.3")
 bazel_dep(name = "bazel_skylib", version = "1.0.3")
+
+nix_repo = use_extension("@rules_nixpkgs_core//extensions:repository.bzl", "nix_repo")
+nix_repo.default(name = "nixpkgs")
+use_repo(nix_repo, "nixpkgs")

--- a/toolchains/nodejs/MODULE.bazel
+++ b/toolchains/nodejs/MODULE.bazel
@@ -11,3 +11,7 @@ bazel_dep(name = "bazel_skylib", version = "1.0.3")
 nix_repo = use_extension("@rules_nixpkgs_core//extensions:repository.bzl", "nix_repo")
 nix_repo.default(name = "nixpkgs")
 use_repo(nix_repo, "nixpkgs")
+
+nix_nodejs = use_extension("//extensions:toolchain.bzl", "nix_nodejs")
+use_repo(nix_nodejs, "nixpkgs_nodejs_toolchains")
+register_toolchains("@nixpkgs_nodejs_toolchains//:all")

--- a/toolchains/nodejs/extensions/BUILD.bazel
+++ b/toolchains/nodejs/extensions/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "toolchain",
+    srcs = ["toolchain.bzl"],
+    visibility = ["//:__pkg__"],
+)

--- a/toolchains/nodejs/extensions/toolchain.bzl
+++ b/toolchains/nodejs/extensions/toolchain.bzl
@@ -1,24 +1,136 @@
 """Defines the nix_nodejs module extension.
 """
 
+load(
+    "//:nodejs.bzl",
+    "DEFAULT_PLATFORMS_MAPPING",
+    "nixpkgs_nodejs_configure",
+)
+
+_DEFAULT_NIXPKGS = "@nixpkgs"
+_DEFAULT_ATTR = "nodejs"
+
 _TOOLCHAINS_REPO = "nixpkgs_nodejs_toolchains"
+_NODEJS_REPO = "nixpkgs_nodejs_{platform}"
+_NODEJS_LABEL = "@{repo}//:nodejs_nix_impl"
+_NODEJS_TOOLCHAIN = """\
+toolchain(
+    name = {name},
+    toolchain = {label},
+    toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
+    exec_compatible_with = {exec_constraints},
+    target_compatible_with = {target_constraints},
+)
+"""
+
+def _nodejs_label(repo_name):
+    return _NODEJS_LABEL.format(repo = repo_name)
+
+def _nodejs_toolchain(*, name, label, exec_constraints, target_constraints):
+    return _NODEJS_TOOLCHAIN.format(
+        name = repr(name),
+        label = repr(label),
+        exec_constraints = repr(exec_constraints),
+        target_constraints = repr(target_constraints),
+    )
+
+def _toolchain_name(*, name, count, prefix_digits):
+    prefix = str(count)
+    prefix = "0" * (prefix_digits - len(prefix)) + prefix
+    return prefix + "-" + name
 
 def _toolchains_repo_impl(repository_ctx):
+    num_toolchains = len(repository_ctx.attr.labels)
+    prefix_digits = len(str(num_toolchains))
+
+    sequence = zip(
+        repository_ctx.attr.names,
+        repository_ctx.attr.labels,
+        repository_ctx.attr.exec_lengths,
+        repository_ctx.attr.target_lengths,
+    )
+
+    exec_offset = 0
+    target_offset = 0
+    builder = []
+
+    for count, (name, label, exec_length, target_length) in enumerate(sequence, start = 1):
+        name = _toolchain_name(
+            name = name,
+            count = count,
+            prefix_digits = prefix_digits,
+        )
+        exec_end = exec_offset + exec_length
+        exec_constraints = repository_ctx.attr.exec_constraints[exec_offset:exec_end]
+        exec_offset = exec_end
+        target_end = target_offset + target_length
+        target_constraints = repository_ctx.attr.target_constraints[target_offset:target_end]
+        target_offset = target_end
+        builder.append(_nodejs_toolchain(
+            name = name,
+            label = label,
+            exec_constraints = exec_constraints,
+            target_constraints = target_constraints,
+        ))
+
     repository_ctx.file(
         "BUILD.bazel",
-        content = "",
+        content = "\n".join(builder),
         executable = False,
     )
 
 _toolchains_repo = repository_rule(
     _toolchains_repo_impl,
     attrs = {
+        "names": attr.string_list(),
+        "labels": attr.string_list(),
+        "exec_constraints": attr.string_list(),
+        "exec_lengths": attr.int_list(),
+        "target_constraints": attr.string_list(),
+        "target_lengths": attr.int_list(),
     },
 )
 
 def _nix_nodejs_impl(module_ctx):
+    toolchain_names = []
+    toolchain_labels = []
+    toolchain_exec_constraints = []
+    toolchain_exec_lengths = []
+    toolchain_target_constraints = []
+    toolchain_target_lengths = []
+
+    for nix_platform, bazel_platform in DEFAULT_PLATFORMS_MAPPING.items():
+        name = bazel_platform.rules_nodejs_platform
+        repo_name = _NODEJS_REPO.format(platform = bazel_platform.rules_nodejs_platform)
+        exec_constraints = [str(Label(c)) for c in bazel_platform.exec_constraints]
+        target_constraints = [str(Label(c)) for c in bazel_platform.target_constraints]
+
+        # TODO[AH] We only need the `nixpkgs_package`, factor it out.
+        nixpkgs_nodejs_configure(
+            name = repo_name,
+            attribute_path = _DEFAULT_ATTR,
+            repository = _DEFAULT_NIXPKGS,
+            nix_platform = nix_platform,
+            exec_constraints = exec_constraints,
+            target_constraints = target_constraints,
+            register = False,
+        )
+
+        toolchain_names.append(name)
+        toolchain_labels.append(_nodejs_label(repo_name))
+        toolchain_exec_constraints.extend(exec_constraints)
+        toolchain_exec_lengths.append(len(exec_constraints))
+        toolchain_target_constraints.extend(target_constraints)
+        toolchain_target_lengths.append(len(target_constraints))
+
     _toolchains_repo(
         name = _TOOLCHAINS_REPO,
+        names = toolchain_names,
+        labels = toolchain_labels,
+        exec_constraints = toolchain_exec_constraints,
+        exec_lengths = toolchain_exec_lengths,
+        target_constraints = toolchain_target_constraints,
+        target_lengths = toolchain_target_lengths,
     )
 
 nix_nodejs = module_extension(

--- a/toolchains/nodejs/extensions/toolchain.bzl
+++ b/toolchains/nodejs/extensions/toolchain.bzl
@@ -1,0 +1,28 @@
+"""Defines the nix_nodejs module extension.
+"""
+
+_TOOLCHAINS_REPO = "nixpkgs_nodejs_toolchains"
+
+def _toolchains_repo_impl(repository_ctx):
+    repository_ctx.file(
+        "BUILD.bazel",
+        content = "",
+        executable = False,
+    )
+
+_toolchains_repo = repository_rule(
+    _toolchains_repo_impl,
+    attrs = {
+    },
+)
+
+def _nix_nodejs_impl(module_ctx):
+    _toolchains_repo(
+        name = _TOOLCHAINS_REPO,
+    )
+
+nix_nodejs = module_extension(
+    _nix_nodejs_impl,
+    tag_classes = {
+    },
+)

--- a/toolchains/nodejs/extensions/toolchain.bzl
+++ b/toolchains/nodejs/extensions/toolchain.bzl
@@ -5,6 +5,7 @@ load(
     "//private:common.bzl",
     "DEFAULT_PLATFORMS_MAPPING",
     "nixpkgs_nodejs",
+    "nodejs_toolchain",
 )
 
 _DEFAULT_NIXPKGS = "@nixpkgs"
@@ -13,26 +14,9 @@ _DEFAULT_ATTR = "nodejs"
 _TOOLCHAINS_REPO = "nixpkgs_nodejs_toolchains"
 _NODEJS_REPO = "nixpkgs_nodejs_{platform}"
 _NODEJS_LABEL = "@{repo}//:nodejs_nix_impl"
-_NODEJS_TOOLCHAIN = """\
-toolchain(
-    name = {name},
-    toolchain = {label},
-    toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
-    exec_compatible_with = {exec_constraints},
-    target_compatible_with = {target_constraints},
-)
-"""
 
 def _nodejs_label(repo_name):
     return _NODEJS_LABEL.format(repo = repo_name)
-
-def _nodejs_toolchain(*, name, label, exec_constraints, target_constraints):
-    return _NODEJS_TOOLCHAIN.format(
-        name = repr(name),
-        label = repr(label),
-        exec_constraints = repr(exec_constraints),
-        target_constraints = repr(target_constraints),
-    )
 
 def _toolchain_name(*, name, count, prefix_digits):
     prefix = str(count)
@@ -66,7 +50,7 @@ def _toolchains_repo_impl(repository_ctx):
         target_end = target_offset + target_length
         target_constraints = repository_ctx.attr.target_constraints[target_offset:target_end]
         target_offset = target_end
-        builder.append(_nodejs_toolchain(
+        builder.append(nodejs_toolchain(
             name = name,
             label = label,
             exec_constraints = exec_constraints,

--- a/toolchains/nodejs/extensions/toolchain.bzl
+++ b/toolchains/nodejs/extensions/toolchain.bzl
@@ -3,8 +3,11 @@
 
 load(
     "//:nodejs.bzl",
-    "DEFAULT_PLATFORMS_MAPPING",
     "nixpkgs_nodejs_configure",
+)
+load(
+    "//private:common.bzl",
+    "DEFAULT_PLATFORMS_MAPPING",
 )
 
 _DEFAULT_NIXPKGS = "@nixpkgs"

--- a/toolchains/nodejs/extensions/toolchain.bzl
+++ b/toolchains/nodejs/extensions/toolchain.bzl
@@ -2,12 +2,9 @@
 """
 
 load(
-    "//:nodejs.bzl",
-    "nixpkgs_nodejs_configure",
-)
-load(
     "//private:common.bzl",
     "DEFAULT_PLATFORMS_MAPPING",
+    "nixpkgs_nodejs",
 )
 
 _DEFAULT_NIXPKGS = "@nixpkgs"
@@ -108,15 +105,11 @@ def _nix_nodejs_impl(module_ctx):
         exec_constraints = [str(Label(c)) for c in bazel_platform.exec_constraints]
         target_constraints = [str(Label(c)) for c in bazel_platform.target_constraints]
 
-        # TODO[AH] We only need the `nixpkgs_package`, factor it out.
-        nixpkgs_nodejs_configure(
+        nixpkgs_nodejs(
             name = repo_name,
+            nix_platform = nix_platform,
             attribute_path = _DEFAULT_ATTR,
             repository = _DEFAULT_NIXPKGS,
-            nix_platform = nix_platform,
-            exec_constraints = exec_constraints,
-            target_constraints = target_constraints,
-            register = False,
         )
 
         toolchain_names.append(name)

--- a/toolchains/nodejs/nodejs.bzl
+++ b/toolchains/nodejs/nodejs.bzl
@@ -1,56 +1,10 @@
 load("@rules_nixpkgs_core//:nixpkgs.bzl", "nixpkgs_package")
 load("@rules_nixpkgs_core//:util.bzl", "ensure_constraints")
-load("@rules_nodejs//nodejs/private:toolchains_repo.bzl", "PLATFORMS")
-
-
-def _mk_mapping(rules_nodejs_platform_name):
-    constraints = PLATFORMS[rules_nodejs_platform_name].compatible_with
-    return struct(
-        rules_nodejs_platform = rules_nodejs_platform_name,
-        exec_constraints = constraints,
-        target_constraints = constraints,
-    )
-
-# obtained (and matched) from:
-# nixpkgs search: https://search.nixos.org/packages?channel=22.11&show=nodejs&from=0&size=50&sort=relevance&type=packages&query=nodejs
-# rules_nodejs: https://github.com/bazelbuild/rules_nodejs/blob/a5755eb458c2dd8e0e2cf9b92d8304d9e77ea117/nodejs/private/toolchains_repo.bzl#L20
-DEFAULT_PLATFORMS_MAPPING = {
-  "aarch64-darwin": _mk_mapping("darwin_arm64"),
-  "x86_64-linux": _mk_mapping("linux_amd64"),
-  "x86_64-darwin": _mk_mapping("darwin_amd64"),
-  "aarch64-linux": _mk_mapping("linux_arm64"),
-}
-
-_nodejs_nix_content = """\
-let
-    pkgs = import <nixpkgs> {{ config = {{}}; overlays = []; system = {nix_platform}; }};
-    nodejs = pkgs.{attribute_path};
-in
-pkgs.buildEnv {{
-  extraOutputsToInstall = ["out" "bin" "lib"];
-  name = "bazel-nodejs-toolchain";
-  paths  = [ nodejs ];
-  postBuild = ''
-    touch $out/ROOT
-    cat <<EOF > $out/BUILD
-
-    filegroup(
-        name = "nodejs",
-        srcs = ["bin/node"],
-        visibility = ["//visibility:public"],
-    )
-
-    load("@rules_nodejs//nodejs:toolchain.bzl", "node_toolchain")
-    node_toolchain(
-        name = "nodejs_nix_impl",
-        target_tool = ":nodejs",
-        visibility = ["//visibility:public"],
-    )
-
-    EOF
-  '';
-}}
-"""
+load(
+    "//private:common.bzl",
+    "DEFAULT_PLATFORMS_MAPPING",
+    "nodejs_nix_file_content",
+)
 
 _nodejs_nix_toolchain = """
 toolchain(
@@ -101,11 +55,12 @@ def nixpkgs_nodejs_configure(
 ):
     if attribute_path == None:
         fail("'attribute_path' is required.", "attribute_path")
+
     if not nix_file and not nix_file_content:
-      nix_file_content = _nodejs_nix_content.format(
-        attribute_path = attribute_path,
-        nix_platform = "builtins.currentSystem" if nix_platform == None else repr(nix_platform),
-      )
+        nix_file_content = nodejs_nix_file_content(
+            attribute_path = attribute_path,
+            nix_platform = nix_platform,
+        )
 
     nixpkgs_package(
         name = name,

--- a/toolchains/nodejs/nodejs.bzl
+++ b/toolchains/nodejs/nodejs.bzl
@@ -3,7 +3,7 @@ load("@rules_nixpkgs_core//:util.bzl", "ensure_constraints")
 load(
     "//private:common.bzl",
     "DEFAULT_PLATFORMS_MAPPING",
-    "nodejs_nix_file_content",
+    "nixpkgs_nodejs",
 )
 
 _nodejs_nix_toolchain = """
@@ -53,17 +53,10 @@ def nixpkgs_nodejs_configure(
   target_constraints = None,
   register = True,
 ):
-    if attribute_path == None:
-        fail("'attribute_path' is required.", "attribute_path")
-
-    if not nix_file and not nix_file_content:
-        nix_file_content = nodejs_nix_file_content(
-            attribute_path = attribute_path,
-            nix_platform = nix_platform,
-        )
-
-    nixpkgs_package(
+    nixpkgs_nodejs(
         name = name,
+        nix_platform = nix_platform,
+        attribute_path = attribute_path,
         repository = repository,
         repositories = repositories,
         nix_file = nix_file,

--- a/toolchains/nodejs/nodejs.bzl
+++ b/toolchains/nodejs/nodejs.bzl
@@ -4,25 +4,17 @@ load(
     "//private:common.bzl",
     "DEFAULT_PLATFORMS_MAPPING",
     "nixpkgs_nodejs",
+    "nodejs_toolchain",
 )
-
-_nodejs_nix_toolchain = """
-toolchain(
-    name = "nodejs_nix",
-    toolchain = "@{toolchain_repo}//:nodejs_nix_impl",
-    toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
-    exec_compatible_with = {exec_constraints},
-    target_compatible_with = {target_constraints},
-)
-"""
 
 def _nixpkgs_nodejs_toolchain_impl(repository_ctx):
     exec_constraints, target_constraints = ensure_constraints(repository_ctx)
     repository_ctx.file(
         "BUILD.bazel",
         executable = False,
-        content = _nodejs_nix_toolchain.format(
-            toolchain_repo = repository_ctx.attr.toolchain_repo,
+        content = nodejs_toolchain(
+            name = "nodejs_nix",
+            label = "@{}//:nodejs_nix_impl".format(repository_ctx.attr.toolchain_repo),
             exec_constraints = exec_constraints,
             target_constraints = target_constraints,
         ),

--- a/toolchains/nodejs/private/BUILD.bazel
+++ b/toolchains/nodejs/private/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "common",
+    srcs = ["common.bzl"],
+    visibility = ["//:__pkg__"],
+)

--- a/toolchains/nodejs/private/BUILD.bazel
+++ b/toolchains/nodejs/private/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
 bzl_library(
     name = "common",
     srcs = ["common.bzl"],

--- a/toolchains/nodejs/private/common.bzl
+++ b/toolchains/nodejs/private/common.bzl
@@ -1,3 +1,4 @@
+load("@rules_nixpkgs_core//:nixpkgs.bzl", "nixpkgs_package")
 load("@rules_nodejs//nodejs/private:toolchains_repo.bzl", "PLATFORMS")
 
 
@@ -64,3 +65,37 @@ def nodejs_nix_file_content(*, attribute_path, nix_platform = None):
         nix_platform = nix_platform,
     )
 
+
+def nixpkgs_nodejs(
+        *,
+        name,
+        nix_platform,
+        attribute_path,
+        repository = None,
+        repositories = {},
+        nix_file = None,
+        nix_file_deps = None,
+        nix_file_content = None,
+        nixopts = [],
+        fail_not_supported = True,
+        quiet = False):
+    if attribute_path == None:
+        fail("'attribute_path' is required.", "attribute_path")
+
+    if not nix_file and not nix_file_content:
+        nix_file_content = nodejs_nix_file_content(
+            attribute_path = attribute_path,
+            nix_platform = nix_platform,
+        )
+
+    nixpkgs_package(
+        name = name,
+        repository = repository,
+        repositories = repositories,
+        nix_file = nix_file,
+        nix_file_deps = nix_file_deps,
+        nix_file_content = nix_file_content,
+        nixopts = nixopts,
+        fail_not_supported = fail_not_supported,
+        quiet = quiet,
+    )

--- a/toolchains/nodejs/private/common.bzl
+++ b/toolchains/nodejs/private/common.bzl
@@ -1,0 +1,66 @@
+load("@rules_nodejs//nodejs/private:toolchains_repo.bzl", "PLATFORMS")
+
+
+def _mk_mapping(rules_nodejs_platform_name):
+    constraints = PLATFORMS[rules_nodejs_platform_name].compatible_with
+    return struct(
+        rules_nodejs_platform = rules_nodejs_platform_name,
+        exec_constraints = constraints,
+        target_constraints = constraints,
+    )
+
+
+# obtained (and matched) from:
+# nixpkgs search: https://search.nixos.org/packages?channel=22.11&show=nodejs&from=0&size=50&sort=relevance&type=packages&query=nodejs
+# rules_nodejs: https://github.com/bazelbuild/rules_nodejs/blob/a5755eb458c2dd8e0e2cf9b92d8304d9e77ea117/nodejs/private/toolchains_repo.bzl#L20
+DEFAULT_PLATFORMS_MAPPING = {
+  "aarch64-darwin": _mk_mapping("darwin_arm64"),
+  "x86_64-linux": _mk_mapping("linux_amd64"),
+  "x86_64-darwin": _mk_mapping("darwin_amd64"),
+  "aarch64-linux": _mk_mapping("linux_arm64"),
+}
+
+
+NODEJS_NIX_FILE_CONTENT = """\
+let
+    pkgs = import <nixpkgs> {{ config = {{}}; overlays = []; system = {nix_platform}; }};
+    nodejs = pkgs.{attribute_path};
+in
+pkgs.buildEnv {{
+  extraOutputsToInstall = ["out" "bin" "lib"];
+  name = "bazel-nodejs-toolchain";
+  paths  = [ nodejs ];
+  postBuild = ''
+    touch $out/ROOT
+    cat <<EOF > $out/BUILD
+
+    filegroup(
+        name = "nodejs",
+        srcs = ["bin/node"],
+        visibility = ["//visibility:public"],
+    )
+
+    load("@rules_nodejs//nodejs:toolchain.bzl", "node_toolchain")
+    node_toolchain(
+        name = "nodejs_nix_impl",
+        target_tool = ":nodejs",
+        visibility = ["//visibility:public"],
+    )
+
+    EOF
+  '';
+}}
+"""
+
+
+def nodejs_nix_file_content(*, attribute_path, nix_platform = None):
+    if nix_platform == None:
+        nix_platform = "builtins.currentSystem"
+    else:
+        nix_platform = repr(nix_platform)
+
+    return NODEJS_NIX_FILE_CONTENT.format(
+        attribute_path = attribute_path,
+        nix_platform = nix_platform,
+    )
+

--- a/toolchains/nodejs/private/common.bzl
+++ b/toolchains/nodejs/private/common.bzl
@@ -54,6 +54,17 @@ pkgs.buildEnv {{
 """
 
 
+NODEJS_TOOLCHAIN_SNIPPET = """\
+toolchain(
+    name = {name},
+    toolchain = {label},
+    toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
+    exec_compatible_with = {exec_constraints},
+    target_compatible_with = {target_constraints},
+)
+"""
+
+
 def nodejs_nix_file_content(*, attribute_path, nix_platform = None):
     if nix_platform == None:
         nix_platform = "builtins.currentSystem"
@@ -98,4 +109,12 @@ def nixpkgs_nodejs(
         nixopts = nixopts,
         fail_not_supported = fail_not_supported,
         quiet = quiet,
+    )
+
+def nodejs_toolchain(*, name, label, exec_constraints, target_constraints):
+    return NODEJS_TOOLCHAIN_SNIPPET.format(
+        name = repr(name),
+        label = repr(label),
+        exec_constraints = repr(exec_constraints),
+        target_constraints = repr(target_constraints),
     )


### PR DESCRIPTION
Closes #480

Provides a module extension to configure a Nix provided NodeJS toolchain.

The extension configures one toolchain per supported platform. This follows the pattern used by the corresponding repository macro.

At this point the module extension is not yet configurable. I.e. it will always use the `nodejs` attribute path in the default `@nixpkgs` repository. Making the toolchain configurable is left open for a follow-up PR.

Note that users can still override this toolchain with their own custom toolchain by invoking the repository macro directly. Users can also override the `@nixpkgs` repo to change the NodeJS toolchain.

- **test-case for nix_nodejs toolchains extension**
- **nix_nodejs module extension scaffolding**
- **testing/nodejs: use nix_repo module extensions**
- **Remove NodeJS toolchain from non_module_deps**
- **Generate and register NodeJS toolchains**
- **Register default NodeJS toolchain**
- **factor out common nodejs definitions**
- **Factor out nixkgs_nodejs**
- **Use nixpkgs_nodejs in module extension**
- **factor out nodejs toolchain snippet**
- **re-use nodejs toolchain snippet**
