### PR TITLE
Use macos-12 runner images explicitly

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-12
         bzlmodEnabled:
           - true
           - false
@@ -75,7 +75,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-12
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The macos-latest runner image was changed to point to macos-14 arm64 already.

Hence, all CI jobs on macos are currently failing: https://github.com/tweag/rules_nixpkgs/actions/runs/8957738476

See https://github.com/github/roadmap/issues/926


