### PR TITLE
Catch case in which find_children is called on an empty dir

### DIFF
--- a/core/nixpkgs.bzl
+++ b/core/nixpkgs.bzl
@@ -469,7 +469,7 @@ def _nixpkgs_build_and_symlink(repository_ctx, nix_build_cmd, expr_args, build_f
     # Nix store.
     for target in find_children(repository_ctx, output_path):
         if target == '':
-            fail("It appears that you nix store may have a corrupt entry. Found empty directory: {}".format(output_path))
+            fail("It appears that your nix store may have a corrupt entry. Found empty directory: {}".format(output_path))
         basename = target.rpartition("/")[-1]
         repository_ctx.symlink(target, basename)
 

--- a/core/nixpkgs.bzl
+++ b/core/nixpkgs.bzl
@@ -468,6 +468,8 @@ def _nixpkgs_build_and_symlink(repository_ctx, nix_build_cmd, expr_args, build_f
     # Build a forest of symlinks (like new_local_package() does) to the
     # Nix store.
     for target in find_children(repository_ctx, output_path):
+        if target == '':
+            fail("It appears that you nix store may have a corrupt entry. Found empty directory: {}".format(output_path))
         basename = target.rpartition("/")[-1]
         repository_ctx.symlink(target, basename)
 

--- a/core/nixpkgs.bzl
+++ b/core/nixpkgs.bzl
@@ -467,9 +467,10 @@ def _nixpkgs_build_and_symlink(repository_ctx, nix_build_cmd, expr_args, build_f
 
     # Build a forest of symlinks (like new_local_package() does) to the
     # Nix store.
-    for target in find_children(repository_ctx, output_path):
-        if target == '':
-            fail("It appears that your nix store may have a corrupt entry. Found empty directory: {}".format(output_path))
+    targets = find_children(repository_ctx, output_path)
+    if not targets:
+        fail("It appears that your nix store may have a corrupt entry. Found empty directory: {}".format(output_path))
+    for target in targets:
         basename = target.rpartition("/")[-1]
         repository_ctx.symlink(target, basename)
 

--- a/core/util.bzl
+++ b/core/util.bzl
@@ -131,7 +131,10 @@ def find_children(repository_ctx, target_dir):
         "-print0",
     ]
     exec_result = execute_or_fail(repository_ctx, find_args)
-    return exec_result.stdout.rstrip("\000").split("\000")
+    if exec_result.stdout != "":
+        return exec_result.stdout.rstrip("\000").split("\000")
+    else:
+        return []  # Special case because splitting the empty string yields [""]
 
 def default_constraints(repository_ctx):
     """Calculate the default CPU and OS constraints based on the host platform.


### PR DESCRIPTION
In our uses, we have found that nix store package corruption can cause a nasty error if `find_children` is called on an empty directory. Specifically, the output of a subprocess call using the find command for `find_children` actually returns `['']` if called on an empty directory. This causes a nasty bug in the for loop designed to "build a forest of symlinks to the nix store" in which symlink gets called incorrectly and causes a tricky bazel error to debug. This change should allow users to get a more helpful error message for debugging purposes.