### PR TITLE
set version field of java_runtime

### DIFF
--- a/toolchains/java/java.bzl
+++ b/toolchains/java/java.bzl
@@ -26,6 +26,7 @@ with import <nixpkgs> { config = {}; overlays = []; };
 { attrPath
 , attrSet
 , filePath
+, javaToolchainVersion
 }:
 
 let
@@ -41,6 +42,10 @@ let
     else
       "${javaHome}/${filePath}"
     ;
+  versionArg = if javaToolchainVersion == null then
+    "# version not set"
+  else
+    "version = ${javaToolchainVersion},";
 in
 
 pkgs.runCommand "bazel-nixpkgs-java-runtime"
@@ -58,6 +63,7 @@ pkgs.runCommand "bazel-nixpkgs-java-runtime"
     java_runtime(
         name = "runtime",
         java_home = r"${javaHomePath}",
+        ${versionArg}
         visibility = ["//visibility:public"],
     )
     EOF
@@ -238,6 +244,12 @@ def nixpkgs_java_configure(
         "filePath",
         java_home_path,
     ])
+    if toolchain_version:
+        nixopts.extend([
+            "--argstr",
+            "javaToolchainVersion",
+            toolchain_version,
+        ])
 
     nixpkgs_package(
         name = name,

--- a/toolchains/java/local_java_repository.bzl
+++ b/toolchains/java/local_java_repository.bzl
@@ -61,6 +61,7 @@ def local_java_runtime(name, java_home, version, runtime_name = None, visibility
         native.java_runtime(
             name = runtime_name,
             java_home = java_home,
+            version = version,
             visibility = visibility,
         )
 


### PR DESCRIPTION
Using JDK 17+, java_test rules fail if Bazel cannot determine the runtime version from the JavaRuntimeInfo provider, since the java security manager was deprecated in that version.

Please note that adding the `version` field unconditionally is only compatible with Bazel 6.2.x and 7.0.0 (or later).
However, during testing I noticed that the Java toolchain already depends on another recent Bazel feature (`@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type`) that was added in 6.4 and 7.0, so this is probably fine.

See also: https://github.com/bazelbuild/bazel/commit/7556e1107b666d10b660470a571631463c7eb4ec

Closes #552