### PR TITLE
Update the rules_nixpkgs guide

### DIFF
--- a/core/util.bzl
+++ b/core/util.bzl
@@ -148,12 +148,14 @@ def default_constraints(repository_ctx):
     cpu_value = get_cpu_value(repository_ctx)
     cpu = {
         "darwin": "@platforms//cpu:x86_64",
+        "darwin_x86_64": "@platforms//cpu:x86_64",
         "darwin_arm64": "@platforms//cpu:arm64",
         "aarch64": "@platforms//cpu:arm64",
     }.get(cpu_value, "@platforms//cpu:x86_64")
     os = {
         "darwin": "@platforms//os:osx",
         "darwin_arm64": "@platforms//os:osx",
+        "darwin_x86_64": "@platforms//os:osx",
     }.get(cpu_value, "@platforms//os:linux")
     return [cpu, os]
 

--- a/examples/cc-template/.bazelrc
+++ b/examples/cc-template/.bazelrc
@@ -1,5 +1,6 @@
 import %workspace%/../../.bazelrc.remote-cache
 
+build --noenable_bzlmod
 build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
 build --crosstool_top=@nixpkgs_config_cc//:toolchain
 

--- a/examples/cc-template/flake.lock
+++ b/examples/cc-template/flake.lock
@@ -17,16 +17,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672580127,
-        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
+        "lastModified": 1718437845,
+        "narHash": "sha256-ZT7Oc1g4I4pHVGGjQFnewFVDRLH5cIZhEzODLz9YXeY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0874168639713f547c05947c76124f78441ea46c",
+        "rev": "752c634c09ceb50c45e751f8791cb45cb3d46c9e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/examples/cc-template/flake.nix
+++ b/examples/cc-template/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     # Track a specific tag on the nixpkgs repo.
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
 
     # The flake format itself is very minimal, so the use of this
     # library is common.

--- a/examples/cc-template/flake.nix
+++ b/examples/cc-template/flake.nix
@@ -30,7 +30,7 @@
 
             # ... which makes available the following dependencies,
             # all sourced from the `pkgs` package set:
-            packages = with pkgs; [ bazel_5 bazel-buildtools cacert nix git ];
+            packages = with pkgs; [ bazel_7 bazel-buildtools cacert nix git ];
           };
       });
 }

--- a/guide.md
+++ b/guide.md
@@ -397,9 +397,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # load rules_nixpkgs
 http_archive(
     name = "io_tweag_rules_nixpkgs",
-    strip_prefix = "rules_nixpkgs-0.9.0",
-    urls = ["https://github.com/tweag/rules_nixpkgs/archive/refs/tags/v0.9.0.tar.gz"],
-    sha256 = "b01f170580f646ee3cde1ea4c117d00e561afaf3c59eda604cf09194a824ff10",
+    sha256 = "2a555348d7f8593fca2bf3fc6ce53c5d62929de81b6c292e23f16c557c0ae45a",
+    strip_prefix = "rules_nixpkgs-0.11.1",
+    urls = ["https://github.com/tweag/rules_nixpkgs/releases/download/v0.11.1/rules_nixpkgs-0.11.1.tar.gz"],
 )
 
 # load everything that rules_nixpkgs rules need to work

--- a/guide.md
+++ b/guide.md
@@ -219,7 +219,7 @@ repository:
 {
   inputs = {
     # Track a specific tag on the nixpkgs repo.
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
 
     # The flake format itself is very minimal, so the use of this
     # library is common.
@@ -300,7 +300,7 @@ play well together.
 As with all dependencies, it's good to upgrade the version of the `nixpkgs`
 input from time to time, which will bump the versions of all Nix-provided
 dependencies. In the example above, the `nixpkgs` dependency is set to follow
-the `nixos-22.05` tag, and we can pull the latest commit from that branch using:
+the `nixos-24.05` tag, and we can pull the latest commit from that branch using:
 
 ```
 $ nix flake lock --update-input nixpkgs
@@ -308,12 +308,12 @@ $ nix flake lock --update-input nixpkgs
 
 It is also possible to change the Nixpkgs dependency to any branch: for
 instance, we could switch to `master` and receive bleeding-edge dependencies, or
-(more practically) we could choose to follow a newer tag (22.11 is available
-right now) by making the following change in `flake.nix`:
+(more practically) we could choose to follow a newer tag (e.g. assume 24.11 is
+available) by making the following change in `flake.nix`:
 
 ```diff
--    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
-+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
+-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
++    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
 ```
 
 To update _all_ dependencies, one uses:
@@ -431,7 +431,7 @@ Nixpkgs commit hash.)
 # A hermetic CC toolchain
 
 We can now define a CC toolchain that will be provisioned by Nix using package
-definitions from the 22.05 release of Nixpkgs.
+definitions from the 24.05 release of Nixpkgs.
 
 ```bazel
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_cc_configure")

--- a/toolchains/cc/cc.bzl
+++ b/toolchains/cc/cc.bzl
@@ -125,7 +125,7 @@ def _parse_cc_toolchain_info(content, filename):
 def _nixpkgs_cc_toolchain_config_impl(repository_ctx):
     host_cpu = get_cpu_value(repository_ctx)
     cpu_value = repository_ctx.attr.cross_cpu or host_cpu
-    darwin = cpu_value == "darwin" or cpu_value == "darwin_arm64"
+    darwin = cpu_value == "darwin" or cpu_value == "darwin_arm64" or cpu_value == "darwin_x86_64"
 
     cc_toolchain_info_file = repository_ctx.path(repository_ctx.attr.cc_toolchain_info)
     if not cc_toolchain_info_file.exists and not repository_ctx.attr.fail_not_supported:

--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -40,10 +40,11 @@ let
         echo "-F${Foundation}/Library/Frameworks" >> $out/nix-support/cc-cflags
         echo "-F${SystemConfiguration}/Library/Frameworks" >> $out/nix-support/cc-cflags
         echo "-L${pkgs.llvmPackages.libcxx}/lib" >> $out/nix-support/cc-cflags
-        echo "-L${pkgs.llvmPackages.libcxxabi}/lib" >> $out/nix-support/cc-cflags
         echo "-L${pkgs.libiconv}/lib" >> $out/nix-support/cc-cflags
         echo "-L${pkgs.darwin.libobjc}/lib" >> $out/nix-support/cc-cflags
         echo "-resource-dir=${pkgs.stdenv.cc}/resource-root" >> $out/nix-support/cc-cflags
+      '' + pkgs.lib.optionalString (builtins.hasAttr "libcxxabi" pkgs.llvmPackages) ''
+        echo "-L${pkgs.llvmPackages.libcxxabi}/lib" >> $out/nix-support/cc-cflags
       '';
     };
   cc =


### PR DESCRIPTION
To use a more recent nixpkgs revision, Bazel 7, and more recent rules_cc.

- **Update nixpkgs revision**
- **Update Bazel to 7.1.0**
- **Update rules_cc**
- **Update guide NixOS 22.05 -> 24.05**
- **Update guide rules_nixpkgs release**
