### PR TITLE
guide: bzlmod version of example

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -95,8 +95,14 @@ jobs:
 
           pushd examples/cc-template
           echo
-          echo "::group::Running $(head -n1 README.md) with Nix"
-          nix develop --command bazel run //src:hello-world
+          echo "::group::Running $(head -n1 README.md) with Nix, WORKSPACE"
+          nix develop --command bazel run --noenable_bzlmod //src:hello-world
+          popd
+
+          pushd examples/cc-template
+          echo
+          echo "::group::Running $(head -n1 README.md) with Nix, bzlmod"
+          nix develop --command bazel run --enable_bzlmod //src:hello-world
           popd
 
           pushd examples/toolchains

--- a/examples/cc-template/.bazelrc
+++ b/examples/cc-template/.bazelrc
@@ -1,6 +1,5 @@
 import %workspace%/../../.bazelrc.remote-cache
 
-build --noenable_bzlmod
-build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
+build --host_platform=@rules_nixpkgs_core//platforms:host
 build --crosstool_top=@nixpkgs_config_cc//:toolchain
 

--- a/examples/cc-template/.gitignore
+++ b/examples/cc-template/.gitignore
@@ -1,2 +1,3 @@
 .direnv/
 bazel-*/
+MODULE.bazel.lock

--- a/examples/cc-template/MODULE.bazel
+++ b/examples/cc-template/MODULE.bazel
@@ -1,0 +1,26 @@
+module(name = "rules_nixpkgs_guide")
+
+bazel_dep(name = "rules_nixpkgs_core")
+local_path_override(
+    module_name = "rules_nixpkgs_core",
+    path = "../../core",
+)
+
+nix_repo = use_extension("@rules_nixpkgs_core//extensions:repository.bzl", "nix_repo")
+nix_repo.file(
+    name = "nixpkgs",
+    file = "//:nixpkgs.nix",
+    file_deps = ["//:flake.lock"],
+)
+use_repo(nix_repo, "nixpkgs")
+
+bazel_dep(name = "rules_nixpkgs_cc")
+local_path_override(
+    module_name = "rules_nixpkgs_cc",
+    path = "../../toolchains/cc",
+)
+
+# TODO remove transitive rules_nixpkgs_cc dependencies.
+#   Once there is a module extension for the cc toolchain.
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_cc", version = "0.0.4")

--- a/examples/cc-template/MODULE.bazel
+++ b/examples/cc-template/MODULE.bazel
@@ -1,6 +1,7 @@
 module(name = "rules_nixpkgs_guide")
 
 bazel_dep(name = "rules_nixpkgs_core")
+# Remove to use rules_nixpkgs_core from the BCR
 local_path_override(
     module_name = "rules_nixpkgs_core",
     path = "../../core",
@@ -15,6 +16,15 @@ nix_repo.file(
 use_repo(nix_repo, "nixpkgs")
 
 bazel_dep(name = "rules_nixpkgs_cc")
+# Replace by archive_override to download a rules_nixpkgs_cc revision.
+# (rules_nixpkgs_cc is not available on the BCR, yet.)
+#
+#     archive_override(
+#         module_name = "rules_nixpkgs_cc",
+#         urls = ["https://github.com/tweag/rules_nixpkgs/releases/download/v0.11.1/rules_nixpkgs-0.11.1.tar.gz"],
+#         integrity = "sha256-KlVTSNf4WT/KK/P8bOU8XWKSnegbbCkuI/FsVXwK5Fo=",
+#         strip_prefix = "rules_nixpkgs-0.11.1/toolchains/cc",
+#     )
 local_path_override(
     module_name = "rules_nixpkgs_cc",
     path = "../../toolchains/cc",

--- a/examples/cc-template/WORKSPACE.bzlmod
+++ b/examples/cc-template/WORKSPACE.bzlmod
@@ -1,0 +1,7 @@
+load("@rules_nixpkgs_cc//:cc.bzl", "nixpkgs_cc_configure")
+
+# TODO Use module extension once available.
+nixpkgs_cc_configure(
+    name = "nixpkgs_config_cc",
+    repository = "@nixpkgs",
+)


### PR DESCRIPTION
Add a bzlmod version of the example for the rules_nixpkgs guide.

The CC toolchain import does not support bzlmod, yet. So, the example still uses the repository rule for that.

- **Enable bzlmod**
- **Document BCR and archive_override**
- **guide: Test WORKSPACE and bzlmod mode on CI**
