### PR TITLE
Tidy up after release

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,2 +1,3 @@
 moduleRoots:
   - "core"
+  - "nodejs"

--- a/.bcr/nodejs/presubmit.yml
+++ b/.bcr/nodejs/presubmit.yml
@@ -1,19 +1,19 @@
-bcr_test_module:
-  module_path: "testing"
-  matrix:
-    platform: ["ubuntu2204"]
-    bazel:
-      - "6.x"
-  tasks:
-    run_tests:
-      name: "Run test module"
-      platform: ${{ platform }}
-      bazel: ${{ bazel }}
-      environment:
-        # The Nix installer updates ~/.profile to set PATH. However, the Bazel
-        # CI setup seems to disregard ~/.profile. So we set PATH manually here.
-        PATH: /var/lib/buildkite-agent/.nix-profile/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-      shell_commands:
-        - curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
-      test_targets:
-        - "//..."
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  # XXX not fully supported yet
+  #- macos_arm64
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  # XXX use testing module once all dependencies are available from the BCR
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@rules_nixpkgs_nodejs//:nodejs'
+    - '@rules_nixpkgs_nodejs//extensions:toolchain'

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Create a bug report to help us fix it.
+labels: 'type: bug'
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment**
+ - OS name + version:
+ - Version of the code:
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project.
+labels: 'type: feature request'
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,4 +41,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create --draft --notes-file release_notes.txt v${{ inputs.version }} rules_nixpkgs-${{ inputs.version }}.tar.gz
+          gh release create \
+            --draft \
+            --notes-file release_notes.txt \
+            --title v${{ inputs.version }} \
+            v${{ inputs.version }} \
+            rules_nixpkgs-${{ inputs.version }}.tar.gz

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -9,13 +9,21 @@ git archive --format=tar.gz --prefix="${PREFIX}/" -o $ARCHIVE HEAD
 SHA=$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')
 
 cat << EOF
-## Using Bzlmod with Bazel 6
+## Using Bzlmod with Bazel 6+
 
 1. Enable with \`common --enable_bzlmod\` in \`.bazelrc\`.
 2. Add to your \`MODULE.bazel\` file:
 
+### For the core module
+
 \`\`\`starlark
 bazel_dep(name = "rules_nixpkgs_core", version = "${TAG:1}")
+\`\`\`
+
+### For the nodejs module
+
+\`\`\`starlark
+bazel_dep(name = "rules_nixpkgs_nodejs", version = "${TAG:1}")
 \`\`\`
 
 ## Using WORKSPACE

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -6,7 +6,7 @@ TAG=$1
 PREFIX="rules_nixpkgs-${TAG:1}"
 ARCHIVE="rules_nixpkgs-${TAG:1}.tar.gz"
 git archive --format=tar.gz --prefix="${PREFIX}/" -o $ARCHIVE HEAD
-SHA=$(shasum -a 256 "$ARCHIVE" | awk '{print $TAG}')
+SHA=$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')
 
 cat << EOF
 ## Using Bzlmod with Bazel 6

--- a/testing/python/vanilla.nix
+++ b/testing/python/vanilla.nix
@@ -1,7 +1,7 @@
 let
   nixpkgs = import <nixpkgs> {};
   filterFun = ps: [ ps.flask ];
-  pythonWithPkgs = nixpkgs.python310.withPackages filterFun;
+  pythonWithPkgs = nixpkgs.python3.withPackages filterFun;
 in {
   python = pythonWithPkgs.python;
   pkgs = filterFun pythonWithPkgs.pkgs;


### PR DESCRIPTION
The release went out :tada: and the core module was published to the BCR.

I had to take care of the nodejs module manually, since I forgot to wire it up in the `.bcr/config.yml`. But it was already published... https://github.com/bazelbuild/bazel-central-registry/pull/2416 :rocket: 

- **Add missing module root for publish-to-bcr**
- **Add title to draft pull request**
- **Fix reference to awk variable**
- **Add back bug report and feature request issue templates**
- **Adapt release body to mention core and nodejs modules**
- **nodejs: Simply verify some target on BCR for now**
