### PR TITLE
Support empty extra_flags_per_feature

### DIFF
--- a/toolchains/cc/cc.bzl
+++ b/toolchains/cc/cc.bzl
@@ -221,7 +221,7 @@ def _nixpkgs_cc_toolchain_config_impl(repository_ctx):
             "%{coverage_compile_flags}": get_starlark_list(info.coverage_compile_flags),
             "%{coverage_link_flags}": get_starlark_list(info.coverage_link_flags),
             "%{supports_start_end_lib}": repr(info.supports_start_end_lib),
-            "%{extra_flags_per_feature}": repr(info.extra_flags_per_feature),
+            "%{extra_flags_per_feature}": repr(dict(info.extra_flags_per_feature)),
             "%{conly_flags}": get_starlark_list(info.conly_flags),
         },
     )

--- a/toolchains/cc/cc.bzl
+++ b/toolchains/cc/cc.bzl
@@ -78,7 +78,6 @@ def _parse_cc_toolchain_info(content, filename):
         "COVERAGE_COMPILE_FLAGS",
         "COVERAGE_LINK_FLAGS",
         "SUPPORTS_START_END_LIB",
-        "EXTRA_FLAGS_PER_FEATURE",
         "IS_CLANG",
         "CONLY_FLAGS",
     ])
@@ -119,7 +118,6 @@ def _parse_cc_toolchain_info(content, filename):
         coverage_compile_flags = info["COVERAGE_COMPILE_FLAGS"],
         coverage_link_flags = info["COVERAGE_LINK_FLAGS"],
         supports_start_end_lib = info["SUPPORTS_START_END_LIB"] == ["True"],
-        extra_flags_per_feature = info["EXTRA_FLAGS_PER_FEATURE"],
         is_clang = info["IS_CLANG"] == ["True"],
         conly_flags = info["CONLY_FLAGS"],
     )
@@ -221,7 +219,7 @@ def _nixpkgs_cc_toolchain_config_impl(repository_ctx):
             "%{coverage_compile_flags}": get_starlark_list(info.coverage_compile_flags),
             "%{coverage_link_flags}": get_starlark_list(info.coverage_link_flags),
             "%{supports_start_end_lib}": repr(info.supports_start_end_lib),
-            "%{extra_flags_per_feature}": repr(dict(info.extra_flags_per_feature)),
+            "%{extra_flags_per_feature}": "{}",
             "%{conly_flags}": get_starlark_list(info.conly_flags),
         },
     )

--- a/toolchains/cc/cc.nix
+++ b/toolchains/cc/cc.nix
@@ -298,7 +298,6 @@ pkgs.runCommand "bazel-${cc.orignalName or cc.name}-toolchain"
         if [[ -x ${cc}/bin/ld.gold ]]; then echo True; else echo False; fi
       )
     )
-    EXTRA_FLAGS_PER_FEATURE=()
     IS_CLANG=(
       ${if cc.isClang then "True" else "False"}
     )
@@ -333,7 +332,6 @@ pkgs.runCommand "bazel-${cc.orignalName or cc.name}-toolchain"
     write_info COVERAGE_COMPILE_FLAGS
     write_info COVERAGE_LINK_FLAGS
     write_info SUPPORTS_START_END_LIB
-    write_info EXTRA_FLAGS_PER_FEATURE
     write_info IS_CLANG
     write_info CONLY_FLAGS
   ''


### PR DESCRIPTION
Used the wrong serialization in https://github.com/tweag/rules_nixpkgs/pull/575. Since this is not really used yet, we set always set an empty dict for now.

Closes https://github.com/tweag/rules_nixpkgs/issues/578