### PR TITLE
Re-enable remote nix tests

### DIFF
--- a/.github/nix-server/Dockerfile
+++ b/.github/nix-server/Dockerfile
@@ -17,8 +17,11 @@ COPY .github/nix-server/keys .
 RUN cat ci.pub > $HOME/.ssh/authorized_keys
 
 RUN echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config && \
+    mkdir -p /run/sshd && \
     echo ". /root/.nix-profile/etc/profile.d/nix.sh" >> $HOME/.bashrc && \
     ln -sf /root/.nix-profile/bin/nix-store /usr/bin/ && \
     ln -sf /root/.nix-profile/bin/nix-daemon /usr/bin/
 
-CMD ["/usr/sbin/sshd", "-D"]
+EXPOSE 22
+
+CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -27,9 +27,7 @@ jobs:
           - true
           - false
         withNixRemote:
-          # FIXME: disable nix-remote checks as they don't work
-          #        see https://github.com/tweag/rules_nixpkgs/issues/564
-          #- true
+          - true
           - false
         exclude:
           # skip nix remote jobs on MacOS


### PR DESCRIPTION
While debugging some other Docker image I noticed that the container did not really start and searching for that error it turned there would be a really simple fix.

The sshd process did not start:
```
Missing privilege separation directory: /run/sshd
```

Ensure to create this directory and make sshd log messages to stderr.

Fixes #564
