### PR TITLE
Add a way to access the output_path in generated BUILD files

### DIFF
--- a/core/nixpkgs.bzl
+++ b/core/nixpkgs.bzl
@@ -478,7 +478,7 @@ def _nixpkgs_build_and_symlink(repository_ctx, nix_build_cmd, expr_args, build_f
     # provided by `build_file` or `build_file_content`.
     if not repository_ctx.path("BUILD").exists and not repository_ctx.path("BUILD.bazel").exists:
         if build_file_content:
-            repository_ctx.file("BUILD", content = build_file_content)
+            repository_ctx.file("BUILD", content = build_file_content.replace("{{NIX_STORE_PATH}}", output_path))
         else:
             repository_ctx.template("BUILD", Label("@rules_nixpkgs_core//:BUILD.bazel.tpl"))
     elif build_file_content:


### PR DESCRIPTION
This is really useful to avoid Bazel seeing the files themselves considering they are already in the nix store. No point in copying them in the bazel cache