### PR TITLE
Do not use wildcards in .bazelignore

### DIFF
--- a/core/.bazelignore
+++ b/core/.bazelignore
@@ -1,2 +1,2 @@
-bazel-*
+bazel-core
 testing

--- a/testing/python/.bazelignore
+++ b/testing/python/.bazelignore
@@ -1,0 +1,1 @@
+bazel-python

--- a/toolchains/java/.bazelignore
+++ b/toolchains/java/.bazelignore
@@ -1,0 +1,1 @@
+bazel-java

--- a/toolchains/nodejs/testing/.bazelignore
+++ b/toolchains/nodejs/testing/.bazelignore
@@ -1,2 +1,1 @@
 bazel-nodejs
-testing

--- a/toolchains/rust/.bazelignore
+++ b/toolchains/rust/.bazelignore
@@ -1,0 +1,1 @@
+bazel-rust


### PR DESCRIPTION
On Windows, Bazel 7 throws an error for these:

```
ERROR: Invalid path in C:/_bzl/minshlu6/external/rules_nixpkgs_core~/.bazelignore: java.nio.file.InvalidPathException: Illegal char <*> at index 6: bazel-*
```
