### PR TITLE
Use `get_cpu_value` from rules_nixpkgs_core in other modules

### DIFF
--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -26,6 +26,7 @@ bzl_library(
     srcs = [
         "nixpkgs.bzl",
         "util.bzl",
+        "private/get_cpu_value.bzl",
     ],
     deps = [
         ":bazel_tools",

--- a/core/private/get_cpu_value.bzl
+++ b/core/private/get_cpu_value.bzl
@@ -1,0 +1,39 @@
+
+# see https://github.com/tweag/rules_nixpkgs/pull/613
+# taken from https://github.com/bazelbuild/rules_cc/blob/8395ec0172270f3bf92cd7b06c9b5b3f1f679e88/cc/private/toolchain/lib_cc_configure.bzl#L225
+def get_cpu_value(repository_ctx):
+    """Compute the cpu_value based on the OS name. Doesn't %-escape the result!
+
+    Args:
+      repository_ctx: The repository context.
+    Returns:
+      One of (darwin, freebsd, x64_windows, ppc, s390x, arm, aarch64, k8, piii)
+    """
+    os_name = repository_ctx.os.name
+    arch = repository_ctx.os.arch
+    if os_name.startswith("mac os"):
+        # Check if we are on x86_64 or arm64 and return the corresponding cpu value.
+        return "darwin_" + ("arm64" if arch == "aarch64" else "x86_64")
+    if os_name.find("freebsd") != -1:
+        return "freebsd"
+    if os_name.find("openbsd") != -1:
+        return "openbsd"
+    if os_name.find("windows") != -1:
+        if arch == "aarch64":
+            return "arm64_windows"
+        else:
+            return "x64_windows"
+
+    if arch in ["power", "ppc64le", "ppc", "ppc64"]:
+        return "ppc"
+    if arch in ["s390x"]:
+        return "s390x"
+    if arch in ["mips64"]:
+        return "mips64"
+    if arch in ["riscv64"]:
+        return "riscv64"
+    if arch in ["arm", "armv7l"]:
+        return "arm"
+    if arch in ["aarch64"]:
+        return "aarch64"
+    return "k8" if arch in ["amd64", "x86_64", "x64"] else "piii"

--- a/core/private/get_cpu_value.bzl
+++ b/core/private/get_cpu_value.bzl
@@ -1,3 +1,4 @@
+load("@bazel_skylib//lib:versions.bzl", "versions")
 
 # see https://github.com/tweag/rules_nixpkgs/pull/613
 # taken from https://github.com/bazelbuild/rules_cc/blob/8395ec0172270f3bf92cd7b06c9b5b3f1f679e88/cc/private/toolchain/lib_cc_configure.bzl#L225
@@ -13,7 +14,15 @@ def get_cpu_value(repository_ctx):
     arch = repository_ctx.os.arch
     if os_name.startswith("mac os"):
         # Check if we are on x86_64 or arm64 and return the corresponding cpu value.
-        return "darwin_" + ("arm64" if arch == "aarch64" else "x86_64")
+        if arch == "aarch64":
+            return "darwin_arm64"
+
+        # NOTE(cb) for backward compatibility return "darwin" for Bazel < 7 on x86_64
+        if versions.is_at_least("7.0.0", versions.get()):
+            return "darwin_x86_64"
+        else:
+            return "darwin"
+
     if os_name.find("freebsd") != -1:
         return "freebsd"
     if os_name.find("openbsd") != -1:

--- a/core/util.bzl
+++ b/core/util.bzl
@@ -1,44 +1,6 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:versions.bzl", "versions")
-
-# see https://github.com/tweag/rules_nixpkgs/pull/613
-# taken from https://github.com/bazelbuild/rules_cc/blob/8395ec0172270f3bf92cd7b06c9b5b3f1f679e88/cc/private/toolchain/lib_cc_configure.bzl#L225
-def get_cpu_value(repository_ctx):
-    """Compute the cpu_value based on the OS name. Doesn't %-escape the result!
-
-    Args:
-      repository_ctx: The repository context.
-    Returns:
-      One of (darwin, freebsd, x64_windows, ppc, s390x, arm, aarch64, k8, piii)
-    """
-    os_name = repository_ctx.os.name
-    arch = repository_ctx.os.arch
-    if os_name.startswith("mac os"):
-        # Check if we are on x86_64 or arm64 and return the corresponding cpu value.
-        return "darwin_" + ("arm64" if arch == "aarch64" else "x86_64")
-    if os_name.find("freebsd") != -1:
-        return "freebsd"
-    if os_name.find("openbsd") != -1:
-        return "openbsd"
-    if os_name.find("windows") != -1:
-        if arch == "aarch64":
-            return "arm64_windows"
-        else:
-            return "x64_windows"
-
-    if arch in ["power", "ppc64le", "ppc", "ppc64"]:
-        return "ppc"
-    if arch in ["s390x"]:
-        return "s390x"
-    if arch in ["mips64"]:
-        return "mips64"
-    if arch in ["riscv64"]:
-        return "riscv64"
-    if arch in ["arm", "armv7l"]:
-        return "arm"
-    if arch in ["aarch64"]:
-        return "aarch64"
-    return "k8" if arch in ["amd64", "x86_64", "x64"] else "piii"
+load("//:private/get_cpu_value.bzl", "get_cpu_value")
 
 def fail_on_err(return_value, prefix = None):
     """Fail if the given return value indicates an error.

--- a/nixpkgs/nixpkgs.bzl
+++ b/nixpkgs/nixpkgs.bzl
@@ -115,7 +115,7 @@ nixpkgs_package(
 
 load("@bazel_tools//tools/cpp:cc_configure.bzl", "cc_autoconf_impl")
 load(
-    "@bazel_tools//tools/cpp:lib_cc_configure.bzl",
+    "@rules_nixpkgs_core//:private/get_cpu_value.bzl",
     "get_cpu_value",
 )
 load(

--- a/toolchains/cc/cc.bzl
+++ b/toolchains/cc/cc.bzl
@@ -23,8 +23,11 @@ using `nixpkgs_cc_configure(..., cc_lang = "cuda")` or similar.
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load(
-    "@bazel_tools//tools/cpp:lib_cc_configure.bzl",
+    "@rules_nixpkgs_core//:private/get_cpu_value.bzl",
     "get_cpu_value",
+)
+load(
+    "@bazel_tools//tools/cpp:lib_cc_configure.bzl",
     "get_starlark_list",
     "write_builtin_include_directory_paths",
 )

--- a/toolchains/go/MODULE.bazel
+++ b/toolchains/go/MODULE.bazel
@@ -4,6 +4,10 @@ module(
 )
 
 bazel_dep(name = "rules_nixpkgs_core", version = "0.12.0")
+local_path_override(
+   module_name = "rules_nixpkgs_core",
+   path = "../../core",
+)
 bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.39.1")
 bazel_dep(name = "bazel_skylib", version = "1.0.3")
 bazel_dep(name = "platforms", version = "0.0.4")

--- a/toolchains/java/MODULE.bazel
+++ b/toolchains/java/MODULE.bazel
@@ -4,6 +4,10 @@ module(
 )
 
 bazel_dep(name = "rules_nixpkgs_core", version = "0.12.0")
+local_path_override(
+   module_name = "rules_nixpkgs_core",
+   path = "../../core",
+)
 bazel_dep(name = "rules_java", version = "7.3.1")
 bazel_dep(name = "bazel_skylib", version = "1.0.3")
 

--- a/toolchains/java/java.bzl
+++ b/toolchains/java/java.bzl
@@ -8,7 +8,7 @@
 """
 
 load(
-    "@bazel_tools//tools/cpp:lib_cc_configure.bzl",
+    "@rules_nixpkgs_core//:private/get_cpu_value.bzl",
     "get_cpu_value",
 )
 load(

--- a/toolchains/nodejs/MODULE.bazel
+++ b/toolchains/nodejs/MODULE.bazel
@@ -4,6 +4,10 @@ module(
 )
 
 bazel_dep(name = "rules_nixpkgs_core", version = "0.12.0")
+local_path_override(
+   module_name = "rules_nixpkgs_core",
+   path = "../../core",
+)
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_nodejs", version = "5.5.3")
 bazel_dep(name = "bazel_skylib", version = "1.0.3")

--- a/toolchains/posix/MODULE.bazel
+++ b/toolchains/posix/MODULE.bazel
@@ -4,5 +4,9 @@ module(
 )
 
 bazel_dep(name = "rules_nixpkgs_core", version = "0.12.0")
+local_path_override(
+   module_name = "rules_nixpkgs_core",
+   path = "../../core",
+)
 bazel_dep(name = "rules_sh", version = "0.3.0")
 bazel_dep(name = "bazel_skylib", version = "1.0.3")

--- a/toolchains/posix/posix.bzl
+++ b/toolchains/posix/posix.bzl
@@ -8,7 +8,7 @@ Rules for importing a POSIX toolchain from Nixpkgs.
 """
 
 load(
-    "@bazel_tools//tools/cpp:lib_cc_configure.bzl",
+    "@rules_nixpkgs_core//:private/get_cpu_value.bzl",
     "get_cpu_value",
 )
 load("@rules_nixpkgs_core//:nixpkgs.bzl", "nixpkgs_package")

--- a/toolchains/python/MODULE.bazel
+++ b/toolchains/python/MODULE.bazel
@@ -4,4 +4,8 @@ module(
 )
 
 bazel_dep(name = "rules_nixpkgs_core", version = "0.12.0")
+local_path_override(
+   module_name = "rules_nixpkgs_core",
+   path = "../../core",
+)
 bazel_dep(name = "bazel_skylib", version = "1.0.3")

--- a/toolchains/rust/MODULE.bazel
+++ b/toolchains/rust/MODULE.bazel
@@ -4,5 +4,9 @@ module(
 )
 
 bazel_dep(name = "rules_nixpkgs_core", version = "0.12.0")
+local_path_override(
+   module_name = "rules_nixpkgs_core",
+   path = "../../core",
+)
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "rules_rust", version = "0.35.0")


### PR DESCRIPTION
This is a follow-up to #613, applying it to other modules. E.g. rules_haskell depends on the posix toolchain which currently also fails with Bazel 8.

Also, make the definition private so we can replace / remove it later.
