### PR TITLE
Add rustfmt_toolchain

### DIFF
--- a/testing/rust/MODULE.bazel
+++ b/testing/rust/MODULE.bazel
@@ -43,7 +43,7 @@ rust.toolchain(
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
 use_repo(non_module_deps, "nixpkgs")
 use_repo(non_module_deps, "nixpkgs_config_rust_toolchain")
-register_toolchains("@nixpkgs_config_rust_toolchain//:rust_nix")
+register_toolchains("@nixpkgs_config_rust_toolchain//:all")
 
 use_repo(non_module_deps, "nixpkgs_config_cc")
 use_repo(non_module_deps, "nixpkgs_config_cc_info")

--- a/toolchains/rust/README.md
+++ b/toolchains/rust/README.md
@@ -2,7 +2,7 @@
 
 <!-- Edit the docstring in `toolchains/rust/rust.bzl` and run `bazel run //docs:update-README.md` to change this repository's `README.md`. -->
 
-Rules for importing a Rust toolchain from Nixpkgs.
+Rules for importing a Rust and rustfmt toolchain from Nixpkgs.
 
 # Rules
 

--- a/toolchains/rust/rust.bzl
+++ b/toolchains/rust/rust.bzl
@@ -1,6 +1,6 @@
 """<!-- Edit the docstring in `toolchains/rust/rust.bzl` and run `bazel run //docs:update-README.md` to change this repository's `README.md`. -->
 
-Rules for importing a Rust toolchain from Nixpkgs.
+Rules for importing a Rust and rustfmt toolchain from Nixpkgs.
 
 # Rules
 
@@ -108,7 +108,7 @@ pkgs.buildEnv {{
             visibility = ["//visibility:public"],
         )
 
-        load('@rules_rust//rust:toolchain.bzl', 'rust_toolchain')
+        load('@rules_rust//rust:toolchain.bzl', 'rust_toolchain', 'rustfmt_toolchain')
         rust_toolchain(
             name = "rust_nix_impl",
             rust_doc = ":rust_doc",
@@ -127,6 +127,12 @@ pkgs.buildEnv {{
             stdlib_linkflags = {stdlib_linkflags},
             visibility = ["//visibility:public"],
         )
+
+        rustfmt_toolchain(
+            name = "rustfmt_nix_impl",
+            rustfmt = ":rustfmt",
+            visibility = ["//visibility:public"],
+        )
         EOF
     '';
 }}
@@ -137,6 +143,14 @@ toolchain(
     name = "rust_nix",
     toolchain = "@{toolchain_repo}//:rust_nix_impl",
     toolchain_type = "@rules_rust//rust:toolchain",
+    exec_compatible_with = {exec_constraints},
+    target_compatible_with = {target_constraints},
+)
+
+toolchain(
+    name = "rustfmt_nix",
+    toolchain = "@{toolchain_repo}//:rustfmt_nix_impl",
+    toolchain_type = "@rules_rust//rust/rustfmt:toolchain_type",
     exec_compatible_with = {exec_constraints},
     target_compatible_with = {target_constraints},
 )


### PR DESCRIPTION
This makes the `nixpkgs_rust_configure` repo rule add a `rustfmt_toolchain` alongside the `rust_toolchain`, using the same `rustfmt` binary as the former.

I ran into this when trying to use the [Prost](https://github.com/tokio-rs/prost) support built into `rules_rust` and it tried to download and invoke a non-nixpkgs `rustfmt`.

I tried updating README files manually since `bazel run @rules_nixpkgs_docs//:update-README.md` didn't seem to do anything. If I'm just holding it wrong, sorry, just let me know.