### PR TITLE
fix remote argument to nixpkgs_git_repository

### DIFF
--- a/core/nixpkgs.bzl
+++ b/core/nixpkgs.bzl
@@ -259,7 +259,7 @@ def nixpkgs_git_repository(
     _nixpkgs_http_repository(
         name = name,
         unmangled_name = name,
-        url = "https://github.com/NixOS/nixpkgs/archive/%s.tar.gz" % revision,
+        url = "%s/archive/%s.tar.gz" % (remote, revision),
         sha256 = sha256,
         strip_prefix = "nixpkgs-%s" % revision,
         **kwargs


### PR DESCRIPTION
remote argument was previously unused