### PR TITLE
vendored cc_toolchain: fix shebang for non-FHS systems

### DIFF
--- a/core/private/cc_toolchain/generate_system_module_map.sh
+++ b/core/private/cc_toolchain/generate_system_module_map.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/private/cc_toolchain/linux_cc_wrapper.sh.tpl
+++ b/core/private/cc_toolchain/linux_cc_wrapper.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/core/private/cc_toolchain/osx_cc_wrapper.sh.tpl
+++ b/core/private/cc_toolchain/osx_cc_wrapper.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #


### PR DESCRIPTION
On NixOS, `/bin/bash` doesn't exist. Use `/usr/bin/env bash` instead.

In order to be compatible with Bazel 8, we had to vendor parts of Bazel's C++ toolchain setup (including shell scripts). Before vendoring said scripts, we would get them from `@bazel_tools//tools/cpp`, which also uses "#!/bin/bash" on vanilla Bazel. The only reason this ever worked on NixOS is that most users use the patched Bazel distribution from nixpkgs, which modifies all scripts to use a different interpreter.

Fixes #622
Fixes #646