### PR TITLE
Use py_runtime_pair from rules_python

### DIFF
--- a/toolchains/python/MODULE.bazel
+++ b/toolchains/python/MODULE.bazel
@@ -9,3 +9,4 @@ local_path_override(
    path = "../../core",
 )
 bazel_dep(name = "bazel_skylib", version = "1.0.3")
+bazel_dep(name = "rules_python", version = "1.8.5")

--- a/toolchains/python/python.bzl
+++ b/toolchains/python/python.bzl
@@ -27,7 +27,7 @@ def _nixpkgs_python_toolchain_impl(repository_ctx):
         python3_runtime = repository_ctx.attr.python3_repo + ":runtime"
 
     repository_ctx.file("BUILD.bazel", executable = False, content = """
-load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
+load("@rules_python//python:defs.bzl", "py_runtime_pair")
 py_runtime_pair(
     name = "py_runtime_pair",
     py3_runtime = {python3_runtime},


### PR DESCRIPTION
py_runtime_pair was completely removed from bazel_tools with bazel 8. Using the version from rules_python should not cause problems for users of bazel 7 and earlier.

I haven't tested with earlier bazel versions. Depending on the supported range of bazel versions, I can test locally.