### PR TITLE
Update old nixos wiki link in the flake examples readme

### DIFF
--- a/examples/flakes/README.md
+++ b/examples/flakes/README.md
@@ -1,7 +1,7 @@
 # bazel-nix-flakes-example
 
 The example is generating a local nixpkgs repository using the `flakes.lock` file already present on
-[flakes](https://nixos.wiki/wiki/Flakes) projects.
+[flakes](https://wiki.nixos.org/wiki/Flakes) projects.
 
 ## Requirements
 


### PR DESCRIPTION
I'm working on replacing all references to `nixos.wiki` with `wiki.nixos.org` across all nix-related repos. This increases visibility of the official wiki so that someday there will no longer be any confusion.