### PR TITLE
Load cc_common and CcToolchainConfigInfo from rules_cc for Bazel 9

### DIFF
--- a/core/private/cc_toolchain/BUILD.tpl
+++ b/core/private/cc_toolchain/BUILD.tpl
@@ -16,7 +16,7 @@
 
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 load(":armeabi_cc_toolchain_config.bzl", "armeabi_cc_toolchain_config")
-load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_toolchain", "cc_toolchain_suite")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/core/private/cc_toolchain/armeabi_cc_toolchain_config.bzl
+++ b/core/private/cc_toolchain/armeabi_cc_toolchain_config.bzl
@@ -19,6 +19,8 @@ load(
     "feature",
     "tool_path",
 )
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/toolchains:cc_toolchain_config_info.bzl", "CcToolchainConfigInfo")
 
 def _impl(ctx):
     toolchain_identifier = "stub_armeabi-v7a"

--- a/core/private/cc_toolchain/unix_cc_toolchain_config.bzl
+++ b/core/private/cc_toolchain/unix_cc_toolchain_config.bzl
@@ -30,6 +30,8 @@ load(
     "variable_with_value",
     "with_feature_set",
 )
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/toolchains:cc_toolchain_config_info.bzl", "CcToolchainConfigInfo")
 
 def _target_os_version(ctx):
     platform_type = ctx.fragments.apple.single_arch_platform.platform_type

--- a/toolchains/cc/MODULE.bazel
+++ b/toolchains/cc/MODULE.bazel
@@ -5,4 +5,8 @@ module(
 
 bazel_dep(name = "rules_nixpkgs_core", version = "0.13.0")
 bazel_dep(name = "bazel_skylib", version = "1.0.3")
-bazel_dep(name = "rules_cc", version = "0.0.1")
+
+# 0.0.17 is the first release providing //cc/common:cc_common.bzl and
+# //cc/toolchains:cc_toolchain_config_info.bzl, which the generated cc
+# toolchain repository loads.
+bazel_dep(name = "rules_cc", version = "0.0.17")


### PR DESCRIPTION
Bazel 9 removed `cc_common`, `CcToolchainConfigInfo`, and `cc_library` from the
global namespace. The toolchain repository generated by `nixpkgs_cc_configure`
still expects them, so the config rule ends up with `provides = [None]` and the
build fails with a `NoneType` error from inside `@nixpkgs_config_cc`. This adds
the missing `rules_cc` loads.

`toolchains/cc/MODULE.bazel` also raises its `rules_cc` floor to 0.0.17, the
first release providing `//cc/common:cc_common.bzl` and
`//cc/toolchains:cc_toolchain_config_info.bzl`. `armeabi_cc_toolchain_config.bzl`
and `BUILD.tpl` are used on every Bazel version, so an older rules_cc would fail
to parse. Happy to drop the bump if you would rather not raise the minimum.

Verified on Bazel 9.0.1: a C++23 `cc_test` compiles, links, and passes against
the nixpkgs toolchain.
