### PR TITLE
Remove redundant --crosstool_top from bzlmod examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,7 @@ nixpkgs_cc_configure(
 This rule depends on [`rules_cc`](https://github.com/bazelbuild/rules_cc).
 
 **Note:**
-You need to configure `--crosstool_top=@<name>//:toolchain` to activate
-this toolchain.
+In bzlmod, use `register_toolchains("@<name>_toolchains//:all")` in your `MODULE.bazel` to activate this toolchain.
 
 
 #### Parameters

--- a/examples/cc-template/.bazelrc
+++ b/examples/cc-template/.bazelrc
@@ -1,5 +1,4 @@
 import %workspace%/../../.bazelrc.remote-cache
 
 build --host_platform=@rules_nixpkgs_core//platforms:host
-build --crosstool_top=@nixpkgs_config_cc//:toolchain
 

--- a/examples/flakes/.bazelrc
+++ b/examples/flakes/.bazelrc
@@ -1,4 +1,3 @@
 import %workspace%/../../.bazelrc.remote-cache
 
 build --host_platform=@rules_nixpkgs_core//platforms:host
-build --crosstool_top=@nixpkgs_config_cc//:toolchain

--- a/examples/python-container/.bazelrc
+++ b/examples/python-container/.bazelrc
@@ -1,4 +1,3 @@
 import %workspace%/../../.bazelrc.remote-cache
 
 build --host_platform=@rules_nixpkgs_core//platforms:host
-build --crosstool_top=@nixpkgs_config_cc//:toolchain

--- a/examples/toolchains/cc/.bazelrc
+++ b/examples/toolchains/cc/.bazelrc
@@ -1,4 +1,3 @@
 import %workspace%/../../../.bazelrc.remote-cache
 
 build:nix --host_platform=@rules_nixpkgs_core//platforms:host --incompatible_enable_cc_toolchain_resolution
-build:nix --crosstool_top=@nixpkgs_config_cc//:toolchain

--- a/examples/toolchains/cc_with_deps/.bazelrc
+++ b/examples/toolchains/cc_with_deps/.bazelrc
@@ -1,4 +1,3 @@
 import %workspace%/../../../.bazelrc.remote-cache
 
 build:nix --host_platform=@rules_nixpkgs_core//platforms:host --incompatible_enable_cc_toolchain_resolution
-build:nix --crosstool_top=@nixpkgs_config_cc//:toolchain

--- a/examples/toolchains/go/.bazelrc
+++ b/examples/toolchains/go/.bazelrc
@@ -1,4 +1,3 @@
 import %workspace%/../../../.bazelrc.remote-cache
 
 build:nix --host_platform=@rules_nixpkgs_core//platforms:host
-build:nix --crosstool_top=@nixpkgs_config_cc//:toolchain

--- a/guide.md
+++ b/guide.md
@@ -470,15 +470,19 @@ of the repository:
 
 ```
 build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
-build --crosstool_top=@nixpkgs_config_cc//:toolchain
+```
+
+In bzlmod, you also need to register the toolchain in your `MODULE.bazel`:
+
+```python
+register_toolchains("@nixpkgs_config_cc_toolchains//:all")
 ```
 
 At a high level, the first directive tells Bazel that we are running on a Nix
 machine, for which special configuration is needed that rules_nixpkgs defines
 (in a similar way to how Bazel makes adjustments when running on macOS vs
-Linux). The second directive tells Bazel to use the toolchain
-`@nixpkgs_config_cc//:toolchain` (which requires Nix support) by default for all
-C++ compilation.
+Linux). The `register_toolchains` call tells Bazel to use the Nix-provided CC
+toolchain by default for all C++ compilation.
 
 Now `bazel build` and `bazel run` should use this toolchain by default for C/C++
 compilation. This can be verified using Bazel's `--toolchain_resolution_debug`
@@ -520,7 +524,12 @@ so, we use `bazelrc` configs to only enable Nix-specific configuration when a
 
 ```
 build:nix --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
-build:nix --crosstool_top=@nixpkgs_config_cc//:toolchain
+```
+
+In bzlmod, you also need to register the toolchain in your `MODULE.bazel`:
+
+```python
+register_toolchains("@nixpkgs_config_cc_toolchains//:all")
 ```
 
 None of these options will apply to `bazel build` or `bazel run` unless an extra

--- a/toolchains/cc/README.md
+++ b/toolchains/cc/README.md
@@ -87,8 +87,7 @@ nixpkgs_cc_configure(
 This rule depends on [`rules_cc`](https://github.com/bazelbuild/rules_cc).
 
 **Note:**
-You need to configure `--crosstool_top=@<name>//:toolchain` to activate
-this toolchain.
+In bzlmod, use `register_toolchains("@<name>_toolchains//:all")` in your `MODULE.bazel` to activate this toolchain.
 
 
 #### Parameters

--- a/toolchains/cc/cc.bzl
+++ b/toolchains/cc/cc.bzl
@@ -377,8 +377,7 @@ def nixpkgs_cc_configure(
     This rule depends on [`rules_cc`](https://github.com/bazelbuild/rules_cc).
 
     **Note:**
-    You need to configure `--crosstool_top=@<name>//:toolchain` to activate
-    this toolchain.
+    In bzlmod, use `register_toolchains("@<name>_toolchains//:all")` in your `MODULE.bazel` to activate this toolchain.
 
     Args:
       attribute_path: optional, string, Obtain the toolchain from the Nix expression under this attribute path. Uses default repository if no `nix_file` or `nix_file_content` is provided.


### PR DESCRIPTION
With bzlmod, `register_toolchains()` in `MODULE.bazel` is sufficient for Bazel to find the Nix-provided CC toolchain. `--crosstool_top` was the old WORKSPACE-era way of explicitly pointing to the toolchain.

Verified by building and running `cc-template` and `flakes` examples without the flag.

We keep `--crosstool_top` in `cc_cross_osx_to_linux_amd64` which needs it for cross-compilation.