### PR TITLE
fix(util): If stat fails, assume the file is not executable.

### DIFF
--- a/core/util.bzl
+++ b/core/util.bzl
@@ -41,6 +41,8 @@ def _is_executable(repository_ctx, path):
 
     arguments = [stat_exe] + stat_args
     exec_result = repository_ctx.execute(arguments)
+    if exec_result.return_code != 0:
+        return False
     stdout = exec_result.stdout.strip()
     mode = int(stdout, 8)
     return mode & 0o100 != 0


### PR DESCRIPTION
On failure, `stdout` is typically empty, and `int(stdout, 8)` will raise an exception, causing unclear output in the Bazel build.

This typically happens if e.g. the file does not exist. If we return `False`, Bazel correctly detects the file is not present and reports a useful error message.