### PR TITLE
chore: switch to the publish-to-BCR workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,32 @@
+name: Publish to Bazel Central Registry (BCR)
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+    secrets:
+      publish_token:
+        required: true
+
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Version to release (e.g. 0.11.0)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.5.0
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      registry_fork: tweag/bazel-central-registry
+      attest: false
+      draft: false
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    secrets:
+      publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: 'Version to release (e.g. 0.11.0)'
+        description: 'Name of the tag to release (e.g. v0.11.0)'
         required: true
         type: string
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,11 +51,10 @@ jobs:
             rules_nixpkgs-${{ inputs.version }}.tar.gz
   publish:
     name: Publish to BCR
-    if: startsWith(github.ref, 'refs/tags/v')
     needs: release
     uses: ./.github/workflows/publish.yaml
     with:
-      tag_name: ${{ inputs.version }}
+      tag_name: v${{ inputs.version }}
     permissions:
       attestations: write
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,3 +49,16 @@ jobs:
             --title v${{ inputs.version }} \
             v${{ inputs.version }} \
             rules_nixpkgs-${{ inputs.version }}.tar.gz
+  publish:
+    name: Publish to BCR
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: release
+    uses: ./.github/workflows/publish.yaml
+    with:
+      tag_name: ${{ inputs.version }}
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
This is needed because the publish-to-BCR app is being discontinued. See this [issue comment](https://github.com/tweag/rules_nixpkgs/issues/749#issuecomment-5567780968) by @avdv