### PR TITLE
Pass v0.14.0 on BCR CI

### DIFF
--- a/examples/toolchains/nodejs/MODULE.bazel
+++ b/examples/toolchains/nodejs/MODULE.bazel
@@ -15,7 +15,7 @@ local_path_override(
 )
 
 bazel_dep(name = "platforms", version = "1.1.0")
-bazel_dep(name = "rules_nodejs", version = "6.3.0")
+bazel_dep(name = "rules_nodejs", version = "6.6.3")
 bazel_dep(name = "aspect_rules_js", version = "2.9.2")
 
 #

--- a/nixpkgs/repositories.bzl
+++ b/nixpkgs/repositories.bzl
@@ -40,9 +40,9 @@ def rules_nixpkgs_dependencies(rules_nixpkgs_name = "io_tweag_rules_nixpkgs", to
     maybe(
         http_archive,
         "rules_nodejs",
-        sha256 = "83d2bb029c2a9a06a474c8748d1221a92a7ca02222dcf49a0b567825c4e3f1ce",
-        strip_prefix = "rules_nodejs-6.3.0",
-        urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.0/rules_nodejs-v6.3.0.tar.gz"],
+        sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        strip_prefix = "rules_nodejs-6.6.3",
+        urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.6.3/rules_nodejs-v6.6.3.tar.gz"],
     )
     maybe(
         http_archive,

--- a/toolchains/nodejs/MODULE.bazel
+++ b/toolchains/nodejs/MODULE.bazel
@@ -8,7 +8,7 @@ local_path_override(
     path = "../../core",
 )
 bazel_dep(name = "platforms", version = "0.0.9")
-bazel_dep(name = "rules_nodejs", version = "6.7.5")
+bazel_dep(name = "rules_nodejs", version = "6.6.3")
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
 
 nix_repo = use_extension("@rules_nixpkgs_core//extensions:repository.bzl", "nix_repo")

--- a/toolchains/nodejs/WORKSPACE
+++ b/toolchains/nodejs/WORKSPACE
@@ -31,9 +31,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_nodejs",
-    sha256 = "83d2bb029c2a9a06a474c8748d1221a92a7ca02222dcf49a0b567825c4e3f1ce",
-    strip_prefix = "rules_nodejs-6.3.0",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.0/rules_nodejs-v6.3.0.tar.gz"],
+    sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    strip_prefix = "rules_nodejs-6.6.3",
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.6.3/rules_nodejs-v6.6.3.tar.gz"],
 )
 
 load("//:nodejs.bzl", "nixpkgs_nodejs_configure")

--- a/toolchains/nodejs/testing/MODULE.bazel
+++ b/toolchains/nodejs/testing/MODULE.bazel
@@ -26,7 +26,7 @@ local_path_override(
 
 bazel_dep(name = "bazel_skylib", version = "1.9.2")
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "rules_nodejs", version = "6.3.0")
+bazel_dep(name = "rules_nodejs", version = "6.6.3")
 
 nix_repo = use_extension("@rules_nixpkgs_core//extensions:repository.bzl", "nix_repo")
 nix_repo.default(name = "nixpkgs")


### PR DESCRIPTION
- [x] :warning: wait for https://github.com/tweag/rules_nixpkgs/pull/767

These changes aim to address 3 failures for `rules_nixpkgs_nodejs`, and 2 for `rules_nixpkgs_core`: https://buildkite.com/bazel/bcr-presubmit/builds/40976/list?sid=01a0852d-b197-4702-b714-1742148c04f7&tab=output